### PR TITLE
fix(funding.entity): Add JoinColumn to tell ORM to set proper column name

### DIFF
--- a/src/entities/funding.entity.ts
+++ b/src/entities/funding.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -38,6 +39,7 @@ export class Funding {
   // fundUuid: string;
 
   @ManyToOne(() => User, (user) => user.fundings)
+  @JoinColumn({ name: 'fundUser' })
   fundUser: User;
 
   @Column('varchar')


### PR DESCRIPTION
#14 와 같이, `JoinColumn` 데코레이터를 사용하여 `fundUserUserId` 이랬던 컬럼 이름을 `fundUser`로 변경했습니다.

> before

![Screenshot 2024-04-14 at 21 56 16](https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/af73e6ff-d64d-45cf-b36c-5876d05ae136)


> after

![Screenshot 2024-04-14 at 21 40 09](https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/5b84be96-333b-480b-bf52-486b07ffded5)

