### PR TITLE
feat: add getNow() for timestamp handling in interceptors and filters

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -105,3 +105,9 @@ import { AuthModule } from './features/auth/auth.module';
   ],
 })
 export class AppModule {}
+
+export function getNow(): string {
+  const event = new Date();
+  event.setTime(event.getTime() - event.getTimezoneOffset() * 60 * 1000);
+  return event.toISOString();
+}

--- a/src/filters/giftogether-exception.filter.ts
+++ b/src/filters/giftogether-exception.filter.ts
@@ -9,10 +9,10 @@ import {
 import { Response } from 'express';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { GiftogetherException } from './giftogether-exception';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { GiftogetherError } from 'src/entities/error.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { request } from 'http';
+import { getNow } from 'src/app.module';
 
 @Catch()
 export class GiftogetherExceptionFilter implements ExceptionFilter {
@@ -42,7 +42,7 @@ export class GiftogetherExceptionFilter implements ExceptionFilter {
 
 
     res.status(err.httpCode).json({
-      timestamp: new Date(),
+      timestamp: getNow(),
       message: msg,
       data: null,
     } as CommonResponse);

--- a/src/transform/transform.interceptor.ts
+++ b/src/transform/transform.interceptor.ts
@@ -1,7 +1,6 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor, SetMetadata } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
-import { Observable, map, timestamp } from 'rxjs';
-import { CommonResponse } from 'src/interfaces/common-response.interface';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+import { getNow } from 'src/app.module';
 
 @Injectable()
 export class TransformInterceptor implements NestInterceptor {
@@ -13,7 +12,7 @@ export class TransformInterceptor implements NestInterceptor {
 				const data = response.data;
 
 				return {
-					timestamp: new Date(),
+					timestamp: getNow(),
 					message: message,
 					data: data
 				};


### PR DESCRIPTION
응답 및 예외 발생 시 클라이언트에게 전달되는 response.timestamp가 timezone이 반영되도록 변경