### PR TITLE
Default Image & (get, create) on Gratitude, Funding

### DIFF
--- a/src/entities/funding.entity.ts
+++ b/src/entities/funding.entity.ts
@@ -17,6 +17,7 @@ import { FundTheme } from 'src/enums/fund-theme.enum';
 import { Gift } from './gift.entity';
 import { Donation } from './donation.entity';
 import { Image } from './image.entity';
+import { ValidateNested } from 'class-validator';
 
 @Entity()
 export class Funding {
@@ -87,9 +88,10 @@ export class Funding {
    * defaultImgId가 null인 경우, Image.subId로 이미지를 가져올 수 있습니다.
    */
   @Column('int', { nullable: true })
-  @OneToOne(() => Image)
+  @OneToOne(() => Image, (image) => image.imgId)
   defaultImgId: number;
 
+  @ValidateNested()
   @OneToMany(() => Image, (image) => image.subId)
   images: Image[];
 

--- a/src/entities/funding.entity.ts
+++ b/src/entities/funding.entity.ts
@@ -9,12 +9,14 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  OneToOne,
 } from 'typeorm';
 import { User } from './user.entity';
 import { Comment } from './comment.entity';
 import { FundTheme } from 'src/enums/fund-theme.enum';
 import { Gift } from './gift.entity';
 import { Donation } from './donation.entity';
+import { Image } from './image.entity';
 
 @Entity()
 export class Funding {
@@ -80,6 +82,16 @@ export class Funding {
     cascade: true,
   })
   donations: Donation[];
+
+  /**
+   * defaultImgId가 null인 경우, Image.subId로 이미지를 가져올 수 있습니다.
+   */
+  @Column('int', { nullable: true })
+  @OneToOne(() => Image)
+  defaultImgId: number;
+
+  @OneToMany(() => Image, (image) => image.subId)
+  images: Image[];
 
   /**
    * TODO - timestamptz를 사용할지, 일반 date를 사용할지 결정해야함.

--- a/src/entities/gratitude.entity.ts
+++ b/src/entities/gratitude.entity.ts
@@ -3,7 +3,8 @@ import {
   Entity,
   CreateDateColumn,
   PrimaryColumn,
-  OneToOne
+  OneToOne,
+  JoinColumn
 } from 'typeorm';
 import { Image } from './image.entity';
 
@@ -27,6 +28,7 @@ export class Gratitude {
   
   @Column('int', { nullable: true })
   @OneToOne(() => Image, (image) => image.imgId)
+  @JoinColumn({ name: 'defaultImgId' })
   defaultImgId: number;
 
   constructor(gratId :number, gratTitle: string, gratCont: string){

--- a/src/entities/gratitude.entity.ts
+++ b/src/entities/gratitude.entity.ts
@@ -2,8 +2,10 @@ import {
   Column,
   Entity,
   CreateDateColumn,
-  PrimaryColumn
+  PrimaryColumn,
+  OneToOne
 } from 'typeorm';
+import { Image } from './image.entity';
 
 @Entity()
 export class Gratitude {
@@ -22,6 +24,10 @@ export class Gratitude {
 
   @Column('bool', { default: false })
   isDel: boolean;
+  
+  @Column('int', { nullable: true })
+  @OneToOne(() => Image, (image) => image.imgId)
+  defaultImgId: number;
 
   constructor(gratId :number, gratTitle: string, gratCont: string){
     this.gratId = gratId;

--- a/src/entities/image.entity.ts
+++ b/src/entities/image.entity.ts
@@ -1,10 +1,5 @@
 import { ImageType } from 'src/enums/image-type.enum';
-import {
-  Column,
-  Entity,
-  PrimaryGeneratedColumn,
-  Index
-} from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, Index } from 'typeorm';
 
 @Entity()
 export class Image {
@@ -20,8 +15,14 @@ export class Image {
     enum: ImageType,
   })
   imgType: ImageType;
-  
+
   @Index({ unique: false })
-  @Column('int')
+  @Column('int', { nullable: true })
   subId: number;
+
+  constructor(imgUrl: string, imgType: ImageType, subId: number) {
+    this.imgUrl = imgUrl;
+    this.imgType = imgType;
+    this.subId = subId;
+  }
 }

--- a/src/entities/image.entity.ts
+++ b/src/entities/image.entity.ts
@@ -1,5 +1,6 @@
 import { ImageType } from 'src/enums/image-type.enum';
-import { Column, Entity, PrimaryGeneratedColumn, Index } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, Index, OneToOne } from 'typeorm';
+import { Gratitude } from './gratitude.entity';
 
 @Entity()
 export class Image {

--- a/src/enums/default-image-id.ts
+++ b/src/enums/default-image-id.ts
@@ -1,0 +1,5 @@
+export enum DefaultImageId {
+  Funding = 1,
+  Gratitude = 2,
+  RollingPape = 3,
+}

--- a/src/enums/error-code.enum.ts
+++ b/src/enums/error-code.enum.ts
@@ -7,6 +7,7 @@ export enum ErrorCode {
   IncorrectGiftUrl = "0200",
   
   // Gratitude
+  GratitudeAlreadyExists = "0300",
   
   // RollingPaper
   

--- a/src/enums/error-code.enum.ts
+++ b/src/enums/error-code.enum.ts
@@ -4,6 +4,7 @@ export enum ErrorCode {
   // Donation
   
   // Gift
+  IncorrectGiftUrl = "0200",
   
   // Gratitude
   
@@ -12,6 +13,7 @@ export enum ErrorCode {
   // Comment
   
   // Image
+  IncorrectImageUrl = "0600",
   
   // User
   UserNotFound = '0700',

--- a/src/enums/error-message.enum.ts
+++ b/src/enums/error-message.enum.ts
@@ -4,6 +4,7 @@ export enum ErrorMsg {
   // Donation
   
   // Gift
+  IncorrectGiftUrl = "선물 URL이 유효하지 않습니다.",
   
   // Gratitude
   
@@ -12,6 +13,7 @@ export enum ErrorMsg {
   // Comment
   
   // Image
+  IncorrectImageUrl = "이미지 URL이 유효하지 않습니다.",
   
   // User
   UserNotFound = '사용자 정보가 없습니다.',

--- a/src/enums/error-message.enum.ts
+++ b/src/enums/error-message.enum.ts
@@ -7,6 +7,7 @@ export enum ErrorMsg {
   IncorrectGiftUrl = "선물 URL이 유효하지 않습니다.",
   
   // Gratitude
+  GratitudeAlreadyExists = "감사인사가 이미 존재합니다.",
   
   // RollingPaper
   

--- a/src/enums/image-type.enum.ts
+++ b/src/enums/image-type.enum.ts
@@ -1,6 +1,7 @@
 export enum ImageType{
   Funding = 'Funding',
-  Donation = 'Donation',
   Gratitude = 'Gratitude',
   RollingPaper = 'RollingPaper',
+  User = "User",
+  Gift = "Gift",
 }

--- a/src/features/funding/dto/create-funding.dto.ts
+++ b/src/features/funding/dto/create-funding.dto.ts
@@ -1,4 +1,5 @@
-import { IsDate, IsDateString, IsUrl, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsDate, IsDateString, IsUrl, Min, ValidateNested } from 'class-validator';
 import { Funding } from 'src/entities/funding.entity';
 import { FundTheme } from 'src/enums/fund-theme.enum';
 import { RequestGiftDto } from 'src/features/gift/dto/request-gift.dto';
@@ -20,6 +21,7 @@ export class CreateFundingDto {
   @IsDateString()
   endAt: Date;
 
-  // TODO - GiftCreateDto
+  @ValidateNested({ each: true })
+  @Type(() => RequestGiftDto)
   gifts: RequestGiftDto[];
 }

--- a/src/features/funding/dto/create-funding.dto.ts
+++ b/src/features/funding/dto/create-funding.dto.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsDateString, Min } from 'class-validator';
+import { IsDate, IsDateString, IsUrl, Min } from 'class-validator';
 import { Funding } from 'src/entities/funding.entity';
 import { FundTheme } from 'src/enums/fund-theme.enum';
 import { RequestGiftDto } from 'src/features/gift/dto/request-gift.dto';
@@ -6,6 +6,7 @@ import { RequestGiftDto } from 'src/features/gift/dto/request-gift.dto';
 export class CreateFundingDto {
   fundTitle: string;
   fundCont: string;
+  @IsUrl({}, { each: true })
   fundImg: string[];
   fundTheme?: FundTheme;
   fundPubl?: boolean;
@@ -20,5 +21,5 @@ export class CreateFundingDto {
   endAt: Date;
 
   // TODO - GiftCreateDto
-  gifts: RequestGiftDto[]
+  gifts: RequestGiftDto[];
 }

--- a/src/features/funding/dto/funding.dto.ts
+++ b/src/features/funding/dto/funding.dto.ts
@@ -14,11 +14,12 @@ export class FundingDto {
   regAt: Date;
   endAt: Date;
   gifts: ResponseGiftDto[];
+  fundImgUrls: string[];
 
-  constructor(funding: Funding, gifts: ResponseGiftDto[]) {
+  constructor(funding: Funding, gifts?: ResponseGiftDto[], fundImgUrls?: string[]) {
     this.fundId = funding.fundId;
     this.fundUuid = funding.fundUuid;
-    this.fundUser = funding.fundUser.userId;
+    this.fundUser = funding.fundUser?.userId;
     this.fundTitle = funding.fundTitle;
     this.fundCont = funding.fundCont;
     this.fundTheme = funding.fundTheme;
@@ -27,6 +28,7 @@ export class FundingDto {
     this.fundSum = funding.fundSum;
     this.regAt = funding.regAt;
     this.endAt = funding.endAt;
-    this.gifts = gifts;
+    this.gifts = gifts || [];
+    this.fundImgUrls = fundImgUrls || [];
   }
 }

--- a/src/features/funding/funding.module.ts
+++ b/src/features/funding/funding.module.ts
@@ -8,11 +8,13 @@ import { Comment } from 'src/entities/comment.entity';
 import { Friend } from 'src/entities/friend.entity';
 import { GiftService } from '../gift/gift.service';
 import { Gift } from 'src/entities/gift.entity';
+import { Image } from 'src/entities/image.entity';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Funding, User, Comment, Friend, Gift])],
+  imports: [TypeOrmModule.forFeature([Funding, User, Comment, Friend, Gift, Image])],
   controllers: [FundingController],
-  providers: [FundingService, GiftService],
+  providers: [FundingService, GiftService, GiftogetherExceptions],
   exports: [FundingService]
 })
 export class FundingModule {}

--- a/src/features/funding/funding.service.ts
+++ b/src/features/funding/funding.service.ts
@@ -11,6 +11,9 @@ import { GiftService } from '../gift/gift.service';
 import { ResponseGiftDto } from '../gift/dto/response-gift.dto';
 import { FundingDto } from './dto/funding.dto';
 import { UpdateFundingDto } from './dto/update-funding.dto';
+import { Image } from 'src/entities/image.entity';
+import { ImageType } from 'src/enums/image-type.enum';
+import { DefaultImageId } from 'src/enums/default-image-id';
 
 @Injectable()
 export class FundingService {
@@ -23,6 +26,9 @@ export class FundingService {
     
     @InjectRepository(Friend)
     private friendRepository: Repository<Friend>,
+    
+    @InjectRepository(Image)
+    private imageRepository: Repository<Image>,
 
     private giftService: GiftService,
   ) {}
@@ -140,12 +146,26 @@ export class FundingService {
       createFundingDto.fundTheme,
       createFundingDto.fundPubl,
     );
+
+    const funding_save = await this.fundingRepository.save(funding);
     
-    await this.fundingRepository.save(funding);
-    
+    if (createFundingDto.fundImg.length > 0) {
+      // subId = fundId, imgType = "Funding" Image 객체를 만든다.
+      const images = createFundingDto.fundImg.map(
+        (url) => new Image(url, ImageType.Funding, funding_save.fundId),
+      );
+      
+      this.imageRepository.save(images);
+    } else {
+      // defaultImgId 필드에 funding 기본 이미지 ID를 넣는다.
+      await this.fundingRepository.update(funding_save.fundId, {
+        defaultImgId: DefaultImageId.Funding,
+      });
+    }
+
     const gifts = await this.giftService.createOrUpdateGift(funding.fundId, createFundingDto.gifts);
-    
-    return new FundingDto(funding, gifts);
+
+    return new FundingDto(funding_save, gifts);
   }
 
   async update(fundUuid: string, updateFundingDto: UpdateFundingDto): Promise<FundingDto> {

--- a/src/features/gift/dto/request-gift.dto.ts
+++ b/src/features/gift/dto/request-gift.dto.ts
@@ -6,7 +6,6 @@ export class RequestGiftDto {
   @IsNumber()
   giftId?: number;
 
-  @IsNotEmpty()
   @IsUrl()
   giftUrl: string;
 

--- a/src/features/gift/dto/request-gift.dto.ts
+++ b/src/features/gift/dto/request-gift.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from "class-transformer";
-import { IsArray, IsNotEmpty, IsNumber, IsOptional, ValidateNested } from "class-validator";
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsUrl, ValidateNested } from "class-validator";
 
 export class RequestGiftDto {
   @IsOptional()
@@ -7,6 +7,7 @@ export class RequestGiftDto {
   giftId?: number;
 
   @IsNotEmpty()
+  @IsUrl()
   giftUrl: string;
 
   @IsNumber()

--- a/src/features/gift/gift.module.ts
+++ b/src/features/gift/gift.module.ts
@@ -7,11 +7,12 @@ import { Module } from "@nestjs/common";
 import { FundingService } from "../funding/funding.service";
 import { User } from "src/entities/user.entity";
 import { Friend } from "src/entities/friend.entity";
+import { GiftogetherExceptions } from "src/filters/giftogether-exception";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Gift, Funding])],
   controllers: [GiftController],
-  providers: [GiftService],
+  providers: [GiftService, GiftogetherExceptions],
   exports: [GiftService],
 })
 export class GiftModule {}

--- a/src/features/gift/gift.service.ts
+++ b/src/features/gift/gift.service.ts
@@ -77,9 +77,6 @@ export class GiftService {
   private async createNewGift(funding: Funding, gift: RequestGiftDto): Promise<Gift> {
     const newGift = new Gift();
     
-    if (!isURL(gift.giftUrl)) {
-      throw this.g2gException.IncorrectImageUrl;
-    }
     newGift.giftUrl = gift.giftUrl;
     newGift.giftOrd = gift.giftOrd;
     newGift.giftOpt = gift.giftOpt;

--- a/src/features/gift/gift.service.ts
+++ b/src/features/gift/gift.service.ts
@@ -5,6 +5,8 @@ import { Gift } from "src/entities/gift.entity";
 import { Repository } from "typeorm";
 import { RequestGiftDto } from "./dto/request-gift.dto";
 import { ResponseGiftDto } from "./dto/response-gift.dto";
+import { isURL } from "class-validator";
+import { GiftogetherExceptions } from "src/filters/giftogether-exception";
 
 @Injectable()
 export class GiftService {
@@ -14,6 +16,8 @@ export class GiftService {
 
     @InjectRepository(Funding)
     private readonly fundingRepository: Repository<Funding>,
+
+    private readonly g2gException: GiftogetherExceptions,
   ) {}
 
   async findAllGift(fundId: number): Promise<{ gifts: ResponseGiftDto[], count: number }> {
@@ -71,6 +75,10 @@ export class GiftService {
   
   private async createNewGift(funding: Funding, gift: RequestGiftDto): Promise<Gift> {
     const newGift = new Gift();
+    
+    if (!isURL(gift.giftUrl)) {
+      throw this.g2gException.IncorrectImageUrl;
+    }
     newGift.giftUrl = gift.giftUrl;
     newGift.giftOrd = gift.giftOrd;
     newGift.giftOpt = gift.giftOpt;

--- a/src/features/gratitude/dto/gratitude.dto.ts
+++ b/src/features/gratitude/dto/gratitude.dto.ts
@@ -1,7 +1,6 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsUrl } from 'class-validator';
 
 export class GratitudeDto {
-
   @IsNotEmpty()
   gratTitle: string;
 
@@ -9,5 +8,6 @@ export class GratitudeDto {
   gratCont: string;
 
   @IsNotEmpty()
+  @IsUrl({}, { each: true })
   gratImg: string[];
 }

--- a/src/features/gratitude/dto/gratitude.dto.ts
+++ b/src/features/gratitude/dto/gratitude.dto.ts
@@ -10,4 +10,10 @@ export class GratitudeDto {
   @IsNotEmpty()
   @IsUrl({}, { each: true })
   gratImg: string[];
+
+  constructor(gratTitle: string, gratCont: string, gratImg?: string[]) {
+    this.gratTitle = gratTitle;
+    this.gratCont = gratCont;
+    this.gratImg = gratImg || [];
+  }
 }

--- a/src/features/gratitude/gratitude.controller.ts
+++ b/src/features/gratitude/gratitude.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Logger, Param, ParseUUIDPipe, Post, Put } from '@nestjs/common';
 import { GratitudeDto } from './dto/gratitude.dto';
 import { GratitudeService } from './gratitude.service';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
+import { Gratitude } from 'src/entities/gratitude.entity';
 
 @Controller('gratitude')
 export class GratitudeController {
@@ -9,16 +10,15 @@ export class GratitudeController {
   
   @Get('/:gratId')
   async getGratitude(
-    @Param('gratId') gratId: number
+    @Param('gratId', ParseUUIDPipe) gratId: string,
   ): Promise<CommonResponse> {
-    return {
-      data: await this.gratitudeService.getGratitude(gratId),
-    };
+    const data = await this.gratitudeService.getGratitude(gratId)
+    return { data };
   }
 
   @Post('/:fundUuid')
   async createGratitude(
-    @Param('fundUuid') fundUuid: string,
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
     @Body() createGratitudeDto: GratitudeDto
   ): Promise<CommonResponse> {
     return {

--- a/src/features/gratitude/gratitude.module.ts
+++ b/src/features/gratitude/gratitude.module.ts
@@ -4,10 +4,12 @@ import { Gratitude } from 'src/entities/gratitude.entity';
 import { GratitudeController } from './gratitude.controller';
 import { GratitudeService } from './gratitude.service';
 import { Funding } from 'src/entities/funding.entity';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { Image } from 'src/entities/image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Gratitude, Funding])],
+  imports: [TypeOrmModule.forFeature([Gratitude, Funding, Image])],
   controllers: [GratitudeController],
-  providers: [GratitudeService],
+  providers: [GratitudeService, GiftogetherExceptions],
 })
 export class GratitudeModule {}

--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -24,10 +24,29 @@ export class GratitudeService {
     private readonly g2gException: GiftogetherExceptions,
   ) {}
 
-  async getGratitude(fundUuid: string) {
+  async getGratitude(fundUuid: string): Promise<GratitudeDto> {
     // TODO find all image url
     const funding = await this.fundingRepo.findOne({ where: { fundUuid } });
-    return this.gratitudeRepo.findOne({ where: { gratId: funding.fundId } });
+    const grat = await this.gratitudeRepo.findOne({
+      where: { gratId: funding.fundId },
+    });
+
+    if (grat.defaultImgId) {
+      const img = await this.imgRepo.findOne({
+        where: { imgId: grat.defaultImgId },
+      });
+      return new GratitudeDto(grat.gratTitle, grat.gratCont, [img.imgUrl]);
+    }
+
+    const images = await this.imgRepo.find({
+      where: { imgType: ImageType.Gratitude, subId: grat.gratId },
+    });
+
+    return new GratitudeDto(
+      grat.gratTitle,
+      grat.gratCont,
+      images.map((img) => img.imgUrl),
+    );
   }
 
   async createGratitude(fundUuid: string, gratitudeDto: GratitudeDto) {

--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -6,6 +6,8 @@ import { GratitudeDto } from './dto/gratitude.dto';
 import { Funding } from 'src/entities/funding.entity';
 import { Image } from 'src/entities/image.entity';
 import { ImageType } from 'src/enums/image-type.enum';
+import { DefaultImageId } from 'src/enums/default-image-id';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 
 @Injectable()
 export class GratitudeService {
@@ -15,43 +17,63 @@ export class GratitudeService {
 
     @InjectRepository(Funding)
     private readonly fundingRepo: Repository<Funding>,
-    
+
     @InjectRepository(Image)
     private readonly imgRepo: Repository<Image>,
+
+    private readonly g2gException: GiftogetherExceptions,
   ) {}
-  
-  async getGratitude(fundUuid: string){
+
+  async getGratitude(fundUuid: string) {
     // TODO find all image url
     const funding = await this.fundingRepo.findOne({ where: { fundUuid } });
-    return this.gratitudeRepo.findOne({ where: { gratId: funding.fundId }});
+    return this.gratitudeRepo.findOne({ where: { gratId: funding.fundId } });
   }
 
   async createGratitude(fundUuid: string, gratitudeDto: GratitudeDto) {
-    const funding = await this.fundingRepo.findOne({ where: {fundUuid}});
+    const funding = await this.fundingRepo.findOne({ where: { fundUuid } });
 
-    const grat = await this.gratitudeRepo.save(new Gratitude(funding.fundId,
-                                                      gratitudeDto.gratTitle,
-                                                      gratitudeDto.gratCont));
-    this.imgRepo.save(
-      gratitudeDto.gratImg.map(
-        (url) => new Image(url, ImageType.Gratitude, grat.gratId),
+    let grat = await this.gratitudeRepo.findOne({
+      where: { gratId: funding.fundId },
+    });
+
+    if (grat) {
+      throw this.g2gException.GratitudeAlreadyExists;
+    }
+
+    grat = await this.gratitudeRepo.save(
+      new Gratitude(
+        funding.fundId,
+        gratitudeDto.gratTitle,
+        gratitudeDto.gratCont,
       ),
     );
-    
+    if (gratitudeDto.gratImg.length > 0) {
+      this.imgRepo.save(
+        gratitudeDto.gratImg.map(
+          (url) => new Image(url, ImageType.Gratitude, grat.gratId),
+        ),
+      );
+    } else {
+      // defaultImgId 필드에 gratitude 기본 이미지 ID를 넣는다.
+      await this.gratitudeRepo.update(grat.gratId, {
+        defaultImgId: DefaultImageId.Gratitude,
+      });
+    }
+
     return grat;
   }
-  
+
   async updateGratitude(gratId: number, gratitudeDto: GratitudeDto) {
-    const gratitude = await this.gratitudeRepo.findOneBy({gratId});
+    const gratitude = await this.gratitudeRepo.findOneBy({ gratId });
     gratitude.gratTitle = gratitudeDto.gratTitle;
     gratitude.gratCont = gratitudeDto.gratCont;
     // TODO update gratitude image
     return await this.gratitudeRepo.save(gratitude);
   }
 
-
-  async deleteGratitude(gratId: number){
-    const gratitude = await this.gratitudeRepo.findOneBy({gratId});
+  async deleteGratitude(gratId: number) {
+    const gratitude = await this.gratitudeRepo.findOneBy({ gratId });
     if (gratitude) {
       console.log(gratitude);
       gratitude.isDel = true;
@@ -62,6 +84,4 @@ export class GratitudeService {
       return false;
     }
   }
-  
-  
 }

--- a/src/filters/giftogether-exception.ts
+++ b/src/filters/giftogether-exception.ts
@@ -22,6 +22,11 @@ export class GiftogetherExceptions {
   // Donation
   
   // Gift
+  IncorrectGiftUrl = new GiftogetherException(
+    ErrorMsg.IncorrectGiftUrl,
+    ErrorCode.IncorrectGiftUrl,
+    HttpStatus.BAD_REQUEST,
+  )
   
   // Gratitude
   
@@ -30,6 +35,11 @@ export class GiftogetherExceptions {
   // Comment
   
   // Image
+  IncorrectImageUrl = new GiftogetherException(
+    ErrorMsg.IncorrectImageUrl,
+    ErrorCode.IncorrectImageUrl,
+    HttpStatus.BAD_REQUEST,
+  )
   
   // User
   UserNotFound = new GiftogetherException(

--- a/src/filters/giftogether-exception.ts
+++ b/src/filters/giftogether-exception.ts
@@ -29,6 +29,11 @@ export class GiftogetherExceptions {
   )
   
   // Gratitude
+  GratitudeAlreadyExists = new GiftogetherException(
+    ErrorMsg.GratitudeAlreadyExists,
+    ErrorCode.GratitudeAlreadyExists,
+    HttpStatus.FORBIDDEN,
+  )
   
   // RollingPaper
   


### PR DESCRIPTION
## Funding Create

이젠 펀딩 객체 생성시 `fundImgUrl`이 존재하면 Image 테이블에 subId를 가진 상태로 row를 추가합니다.

![Screenshot 2024-05-15 at 01 46 38](https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/39c25b7b-484a-479a-add2-06b868a05296)

## Funding Retrieval

펀딩 객체 가져올 때 제일 먼저 `defaultImgId`가 NULL인지 확인하여 이미지 참조 id를 결정합니다.

- 만약 NULL이라면, Image 테이블의 subid & imgType 필드를 사용하여 이미지를 가져옵니다.
- NULL이 아니라면, Image 테이블의 imgId 필드를 사용하여 이미지를 가져옵니다.

<img width="956" alt="Screenshot 2024-05-15 at 02 32 35" src="https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/863c32c8-c79e-4594-9151-de06f53728d6">

## Gratitude Create

이젠 Gratitude 객체 생성시 `gratImgUrl`이 존재하면 Image 테이블에 subId를 가진 상태로 row를 추가합니다.

<img width="752" alt="Screenshot 2024-05-15 at 02 41 55" src="https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/95c1f350-a4d2-4d66-ae50-09d7e0f996c8">

## Gratitude Retrieval

이젠 Gratitude 객체 가져올 때 제일 먼저 `defaultImgId`가 NULL인지 확인하여 이미지 참조 id를 결정합니다. Funding Retrieval과 동일합니다.

<img width="752" alt="Screenshot 2024-05-15 at 02 43 04" src="https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/d88b445e-1e3d-4aa4-ab7a-ffe4359a21d9">

