### PR TITLE
WISH-121-rolling_paper-default-image

### DIFF
--- a/src/entities/rolling-paper.entity.ts
+++ b/src/entities/rolling-paper.entity.ts
@@ -7,6 +7,7 @@ import {
   DeleteDateColumn,
 } from 'typeorm';
 import { Donation } from './donation.entity';
+import { Image } from './image.entity';
 
 @Entity()
 export class RollingPaper {
@@ -20,9 +21,10 @@ export class RollingPaper {
   @Column()
   fundId: number;
 
-  // @OneToOne(() => Image, img => img.imgId)
-  // @JoinColumn({ name: 'rollImg' })
-  // rollImg: string;
+  @Column('int', { nullable: true })
+  @OneToOne(() => Image, (image) => image.imgId)
+  @JoinColumn({ name: 'defaultImgId' })
+  defaultImgId: number;
 
   @Column({ default: '축하해요' })
   rollMsg: string;

--- a/src/entities/rolling-paper.entity.ts
+++ b/src/entities/rolling-paper.entity.ts
@@ -15,7 +15,7 @@ export class RollingPaper {
   rollId: number;
 
   @OneToOne(() => Donation, { cascade: true })
-  @JoinColumn({ name: 'donId', referencedColumnName: 'donId' })
+  @JoinColumn({ name: 'rollId', referencedColumnName: 'donId' })
   donation: Donation;
 
   @Column()

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -40,7 +40,7 @@ export class User {
   @Column({ unique: true, nullable: true })
   userPhone: string;
 
-  @Column()
+  @Column({nullable: true})
   userEmail: string;
 
   @Column('date', { nullable: true })

--- a/src/enums/default-image-id.ts
+++ b/src/enums/default-image-id.ts
@@ -1,5 +1,5 @@
 export enum DefaultImageId {
   Funding = 1,
   Gratitude = 2,
-  RollingPape = 3,
+  RollingPaper = 3,
 }

--- a/src/features/donation/donation.module.ts
+++ b/src/features/donation/donation.module.ts
@@ -7,9 +7,10 @@ import { Donation } from 'src/entities/donation.entity';
 import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { Funding } from 'src/entities/funding.entity';
 import { User } from 'src/entities/user.entity';
+import { Image } from 'src/entities/image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Donation, RollingPaper, Funding, User])],
+  imports: [TypeOrmModule.forFeature([Donation, RollingPaper, Funding, User, Image])],
   controllers: [DonationController],
   providers: [DonationService, RollingPaperService],
 })

--- a/src/features/donation/donation.service.ts
+++ b/src/features/donation/donation.service.ts
@@ -55,7 +55,10 @@ export class DonationService {
     return result;
   }
 
-  async createOrFindDonator(userId: number, guest: CreateGuestDto) {
+  async createOrFindDonator(
+    userId: number,
+    guest: CreateGuestDto,
+  ): Promise<User> {
     if (guest) {
       const { userNick, userPhone, accBank, accNum } = guest;
       const user = new User();
@@ -64,17 +67,20 @@ export class DonationService {
       user.userNick = userNick;
       user.userPhone = userPhone;
       // user.accId = 1;
-      return await this.userRepo.save(user);
+      return this.userRepo.save(user);
     }
-    return await this.userRepo.findOne({ where: { userId } });
+    return this.userRepo.findOne({ where: { userId } });
   }
 
   async updateFundingSum(funding: Funding, donAmnt: number) {
+    funding.fundSum += donAmnt;
     // TODO 펀딩 목표금액 달성 확인 후 Notification
-    return await this.fundingRepo.save({
-      fundId: funding.fundId,
-      fundSum: funding.fundSum + donAmnt,
-    });
+    await this.fundingRepo.update(
+      { fundId: funding.fundId },
+      { fundSum: funding.fundSum },
+    );
+
+    return funding;
   }
 
   // CREATE
@@ -89,10 +95,8 @@ export class DonationService {
 
     const funding = await this.fundingRepo.findOne({ where: { fundUuid } });
 
-    Logger.log(JSON.stringify(user));
-    Logger.log(JSON.stringify(funding));
-
     const updateFunding = await this.updateFundingSum(funding, donAmnt);
+    Logger.log('왔니2');
 
     const donation = new Donation();
     donation.user = user;

--- a/src/features/donation/dto/create-donation.dto.ts
+++ b/src/features/donation/dto/create-donation.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsNumber, IsUrl } from 'class-validator';
 import { CreateGuestDto } from './create-guest.dto';
 
 export class CreateDonationDto {
@@ -8,9 +8,11 @@ export class CreateDonationDto {
   @IsNumber()
   donAmnt: number;
 
-  @IsNotEmpty()
+  @IsOptional()
+  @IsString()
   rollMsg: string;
 
-  @IsNotEmpty()
+  @IsOptional()
+  @IsUrl()
   rollImg: string;
 }

--- a/src/features/rolling-paper/dto/create-rolling-paper.dto.ts
+++ b/src/features/rolling-paper/dto/create-rolling-paper.dto.ts
@@ -1,0 +1,23 @@
+import { IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateRollingPaperDto {
+  @IsNumber()
+  donId: number;
+
+  @IsOptional()
+  @IsString()
+  rollMsg: string;
+
+  /**
+   * NULLABLE, null이라면 default image를 자동으로 적용합니다.
+   */
+  @IsOptional()
+  @IsUrl()
+  rollImg?: string;
+
+  constructor(donId: number, rollMsg?: string, rollImg?: string) {
+    this.donId = donId;
+    this.rollMsg = rollMsg;
+    this.rollImg = rollImg;
+  }
+}

--- a/src/features/rolling-paper/dto/rolling-paper.dto.ts
+++ b/src/features/rolling-paper/dto/rolling-paper.dto.ts
@@ -1,18 +1,21 @@
 import { RollingPaper } from 'src/entities/rolling-paper.entity';
+import { IsUrl } from 'class-validator';
 export class RollingPaperDto {
   rollId: number;
   rollMsg: string;
   regAt: Date;
   donAmnt: number;
   userNick: string;
+  
+  @IsUrl()
+  rollImg: string;
 
-  constructor(rollingPaper: RollingPaper) {
+  constructor(rollingPaper: RollingPaper, rollImg: string) {
     this.rollId = rollingPaper.rollId;
     this.rollMsg = rollingPaper.rollMsg;
-    // rollImg;
+    this.rollImg = rollImg;
     this.regAt = rollingPaper.donation.regAt;
     this.donAmnt = rollingPaper.donation.donAmnt;
     this.userNick = rollingPaper.donation.user.userNick;
-    // userImage
   }
 }

--- a/src/features/rolling-paper/rolling-paper.controller.ts
+++ b/src/features/rolling-paper/rolling-paper.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
 import { RollingPaperService } from './rolling-paper.service';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 
@@ -6,13 +6,13 @@ import { CommonResponse } from 'src/interfaces/common-response.interface';
 export class RollingPaperController {
   constructor(private rollingPaperService: RollingPaperService) {}
 
-  @Get('/:fundId')
+  @Get('/:fundUuid')
   async getAllRollingPapers(
-    @Param('fundId') fundId: number,
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
   ): Promise<CommonResponse> {
     return {
       message: 'RollingPaper 조회 성공',
-      data: await this.rollingPaperService.getAllRollingPapers(fundId),
+      data: await this.rollingPaperService.getAllRollingPapers(fundUuid),
     };
   }
 }

--- a/src/features/rolling-paper/rolling-paper.module.ts
+++ b/src/features/rolling-paper/rolling-paper.module.ts
@@ -4,9 +4,10 @@ import { RollingPaperService } from './rolling-paper.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { Funding } from 'src/entities/funding.entity';
+import { Image } from 'src/entities/image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RollingPaper, Funding])],
+  imports: [TypeOrmModule.forFeature([RollingPaper, Funding, Image])],
   controllers: [RollingPaperController],
   providers: [RollingPaperService],
 })

--- a/src/features/rolling-paper/rolling-paper.service.ts
+++ b/src/features/rolling-paper/rolling-paper.service.ts
@@ -3,20 +3,53 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { Repository } from 'typeorm';
 import { RollingPaperDto } from './dto/rolling-paper.dto';
+import { Funding } from 'src/entities/funding.entity';
+import { Image } from 'src/entities/image.entity';
+import { DefaultImageId } from 'src/enums/default-image-id';
+import { ImageType } from 'src/enums/image-type.enum';
 
 @Injectable()
 export class RollingPaperService {
   constructor(
     @InjectRepository(RollingPaper)
     private readonly rollingPaperRepo: Repository<RollingPaper>,
+
+    @InjectRepository(Funding)
+    private readonly fundingRepo: Repository<Funding>,
+
+    @InjectRepository(Image)
+    private readonly imgRepo: Repository<Image>,
   ) {}
 
-  async getAllRollingPapers(fundId: number): Promise<RollingPaperDto[]> {
+  async getAllRollingPapers(fundUuid: string): Promise<RollingPaperDto[]> {
+    const fund = await this.fundingRepo.findOne({ where: { fundUuid } });
     const rolls = await this.rollingPaperRepo.find({
-      where: { fundId: fundId },
+      where: { fundId: fund.fundId },
       relations: ['donation', 'donation.user'],
     });
 
-    return rolls.map((roll) => new RollingPaperDto(roll));
+    const getImageUrl = async (roll: RollingPaper): Promise<string> => {
+      if (roll.defaultImgId) {
+        return (
+          await this.imgRepo.findOne({
+            where: { imgId: DefaultImageId.RollingPaper },
+          })
+        )?.imgUrl;
+      }
+
+      // not a default
+      return (
+        await this.imgRepo.findOne({
+          where: { imgType: ImageType.RollingPaper, subId: roll.rollId },
+        })
+      ).imgUrl;
+    };
+
+    const resolvedRolls = await Promise.all(rolls);
+    const dtoPromises = resolvedRolls.map(async (roll) => {
+      const imageUrl = await getImageUrl(roll);
+      return new RollingPaperDto(roll, imageUrl);
+    });
+    return Promise.all(dtoPromises);
   }
 }

--- a/src/features/rolling-paper/rolling-paper.service.ts
+++ b/src/features/rolling-paper/rolling-paper.service.ts
@@ -7,6 +7,8 @@ import { Funding } from 'src/entities/funding.entity';
 import { Image } from 'src/entities/image.entity';
 import { DefaultImageId } from 'src/enums/default-image-id';
 import { ImageType } from 'src/enums/image-type.enum';
+import { Donation } from 'src/entities/donation.entity';
+import { CreateRollingPaperDto } from './dto/create-rolling-paper.dto';
 
 @Injectable()
 export class RollingPaperService {
@@ -51,5 +53,42 @@ export class RollingPaperService {
       return new RollingPaperDto(roll, imageUrl);
     });
     return Promise.all(dtoPromises);
+  }
+
+  /**
+   * DonationService.createDonation시에 동시에 같이 생성이 되는 메서드입니다.
+   * 따라서 별개의 컨트롤러는 없고 오직 DonationService에 의해서 호출됩니다.
+   * @param fundUuid
+   */
+  async createRollingPaper(
+    fundId: number,
+    donation: Donation,
+    crpDto: CreateRollingPaperDto,
+  ): Promise<RollingPaper> {
+    const rollingPaper = new RollingPaper();
+    rollingPaper.rollId = donation.donId;
+    rollingPaper.donation = donation;
+    rollingPaper.rollMsg = crpDto.rollMsg;
+    rollingPaper.fundId = fundId;
+
+    const savedRp = await this.rollingPaperRepo.save(rollingPaper);
+
+    if (crpDto.rollImg) {
+      // 사용자 정의 이미지
+      const image = new Image(
+        crpDto.rollImg,
+        ImageType.RollingPaper,
+        rollingPaper.rollId,
+      );
+
+      this.imgRepo.save(image);
+    } else {
+      // 기본값 이미지
+      this.rollingPaperRepo.update(savedRp.rollId, {
+        defaultImgId: DefaultImageId.RollingPaper,
+      });
+    }
+
+    return savedRp;
   }
 }


### PR DESCRIPTION
rolling paper가 혼자서만 생성이 될 수는 없고, donation 생성과 같이 따라가기 때문에 조금 어려웠습니다. donation 생성시 rolling paper가 동시에 생기게 되고, 여기에서 guest 유무에 따라서 동작하게 만들어놓았습니다.

본래의 업무였던 `defaultImgId` 필드는 생성하였고, 영향을 받는 엔티티는 `RollingPaper`와 `User` 입니다. 뜬금없이 `User` 엔티티가 나온 이유는, guest에 `userEmail` 필드가 없는데 nullable이 false라서 게스트 유저가 생성이 안됐습니다.