### PR TITLE
WISH-190-logindto

### DIFF
--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -99,8 +99,8 @@ export class AuthService {
     }
   }
 
-  async isValidPassword(reqPw: string, storedPw: string): Promise<Boolean> {
-    const isValidPw = await bcrypt.compare(reqPw, storedPw);
+  async isValidPassword(plainPw: string, hashPw: string): Promise<Boolean> {
+    const isValidPw = await bcrypt.compare(plainPw, hashPw);
     if (!isValidPw) {
       throw this.jwtException.PasswordIncorrect;
     }
@@ -116,7 +116,7 @@ export class AuthService {
       throw this.jwtException.UserNotFound;
     }
 
-    await this.isValidPassword(user.userPw, loginDto.userPw);
+    await this.isValidPassword(loginDto.userPw, user.userPw);
 
     let imgUrl = null;
     if (user.defaultImgId) {

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -110,7 +110,7 @@ export class AuthService {
   async login(loginDto: LoginDto): Promise<UserDto> {
     //TODO 패스워드 db 비교
     const user = await this.userRepository.findOne({
-      where: { userEmail: loginDto.userEmail },
+      where: { userNick: loginDto.userNick },
     });
     if (!user) {
       throw this.jwtException.UserNotFound;

--- a/src/features/auth/dto/login.dto.ts
+++ b/src/features/auth/dto/login.dto.ts
@@ -1,8 +1,8 @@
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class LoginDto {
   @IsNotEmpty()
-  @IsEmail()
+  @IsString()
   userNick: string;
 
   @IsNotEmpty()

--- a/src/features/auth/dto/login.dto.ts
+++ b/src/features/auth/dto/login.dto.ts
@@ -3,7 +3,7 @@ import { IsEmail, IsNotEmpty } from 'class-validator';
 export class LoginDto {
   @IsNotEmpty()
   @IsEmail()
-  userEmail: string;
+  userNick: string;
 
   @IsNotEmpty()
   userPw: string;


### PR DESCRIPTION
일반 이메일 회원가입 유저들이 login이 안되는 문제를 발견했습니다. login 서비스에서 `isValidPassword` 함수를 호출할때 인자 순서가 바뀌어 있었던 문제입니다. [bcrypt](https://www.npmjs.com/package/bcrypt) 참조

이제는 아래와 같이 잘 됩니다.

<img width="604" alt="Screenshot 2024-07-06 at 22 02 27" src="https://github.com/coding-jjun/wishlist_funding_backend/assets/18757823/6a1f57bc-c54c-46c7-bbeb-2d7cb5f7d025">

