### PR TITLE
fix(funding)

### DIFF
--- a/src/features/funding/funding.controller.ts
+++ b/src/features/funding/funding.controller.ts
@@ -1,23 +1,16 @@
 import {
   Body,
   Controller,
-  DefaultValuePipe,
   Delete,
   Get,
-  HttpException,
-  HttpStatus,
-  Logger,
   Param,
-  ParseIntPipe,
   ParseUUIDPipe,
   Post,
   Put,
-  Query,
 } from '@nestjs/common';
 import { FundingService } from './funding.service';
 import { CreateFundingDto } from './dto/create-funding.dto';
 import { UpdateFundingDto } from './dto/update-funding.dto';
-import { FundTheme } from 'src/enums/fund-theme.enum';
 import { GiftArray } from '../gift/dto/request-gift.dto';
 import { GiftService } from '../gift/gift.service';
 import { CommonResponse } from 'src/interfaces/common-response.interface';

--- a/src/features/funding/funding.controller.ts
+++ b/src/features/funding/funding.controller.ts
@@ -1,12 +1,17 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
+  ParseIntPipe,
   ParseUUIDPipe,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { FundingService } from './funding.service';
 import { CreateFundingDto } from './dto/create-funding.dto';
@@ -14,6 +19,7 @@ import { UpdateFundingDto } from './dto/update-funding.dto';
 import { GiftArray } from '../gift/dto/request-gift.dto';
 import { GiftService } from '../gift/gift.service';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
+import { FundTheme } from 'src/enums/fund-theme.enum';
 
 @Controller('funding')
 export class FundingController {
@@ -49,6 +55,42 @@ export class FundingController {
       };
     } catch (error) {
       throw error;
+    }
+  }
+
+  @Get()
+  async findAll(
+    @Query('fundThemes', new DefaultValuePipe([
+      FundTheme.Anniversary,
+      FundTheme.Birthday,
+      FundTheme.Donation,
+    ])) fundThemes: FundTheme | FundTheme[],
+    @Query('status', new DefaultValuePipe('ongoing')) status: 'ongoing' | 'ended',
+    @Query('sort', new DefaultValuePipe('endAtDesc')) sort: 'endAtAsc' | 'endAtDesc' | 'regAtAsc' | 'regAtDesc',
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('lastFundUuid', new DefaultValuePipe(undefined)) lastFundUuid?: string,
+    @Query('lastEndAt', new DefaultValuePipe(undefined)) lastEndAt?: string,
+  ): Promise<CommonResponse> {
+    try {
+      const themesArray = Array.isArray(fundThemes) ? fundThemes : [fundThemes];
+      const lastEndAtDate = lastEndAt ? new Date(lastEndAt) : undefined;
+      const data = await this.fundingService.findAll(
+        0,
+        'all',
+        themesArray,
+        status,
+        sort,
+        limit,
+        lastFundUuid,
+        lastEndAtDate,
+      )
+
+      return {
+        message: 'Success',
+        data
+      };
+    } catch (error) {
+      throw new HttpException('Failed to get fundings', HttpStatus.BAD_REQUEST);
     }
   }
 

--- a/src/features/user/user.controller.ts
+++ b/src/features/user/user.controller.ts
@@ -8,6 +8,7 @@ import {
   HttpStatus,
   Param,
   ParseIntPipe,
+  ParseUUIDPipe,
   Post,
   Put,
   Query,
@@ -20,6 +21,7 @@ import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { FundingService } from '../funding/funding.service';
 import { FundTheme } from 'src/enums/fund-theme.enum';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { UUID } from 'crypto';
 
 @Controller('user')
 export class UserController {
@@ -63,8 +65,7 @@ export class UserController {
     @Query('sort', new DefaultValuePipe('endAtDesc'))
     sort: 'endAtAsc' | 'endAtDesc' | 'regAtAsc' | 'regAtDesc',
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
-    @Query('lastFundId', new DefaultValuePipe(0), ParseIntPipe)
-    lastFundId?: number,
+    @Query('lastFundUuid', new DefaultValuePipe(undefined)) lastFundUuid?: string,
     @Query('lastEndAt', new DefaultValuePipe(undefined)) lastEndAt?: string,
   ): Promise<CommonResponse> {
     try {
@@ -77,7 +78,7 @@ export class UserController {
         status,
         sort,
         limit,
-        lastFundId,
+        lastFundUuid,
         lastEndAtDate,
       );
 


### PR DESCRIPTION
- 펀딩 리스트 조회시 무한 스크롤을 위해 전달하는 마지막 조회된 펀딩의 id를 전달해왔다.
그렇게 되면 다음 페이지 요청시에 query Parameter에 fundId가 노출된다.
response에 fundId 대신 fundUuid 전달하도록 변경

- 비회원용 펀딩 리스트 조회 API 추가
