### PR TITLE
WISH-183-task-scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/mapped-types": "^2.0.5",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^4.1.0",
         "@nestjs/typeorm": "^10.0.2",
         "@redis/client": "^1.5.16",
         "@types/bcrypt": "^5.0.2",
@@ -3135,6 +3136,33 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.1.0.tgz",
+      "integrity": "sha512-WEc96WTXZW+VI/Ng+uBpiBUwm6TWtAbQ4RKWkfbmzKvmbRGzA/9k/UyAWDS9k0pp+ZcbC+MaZQtt7TjQHrwX6g==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.1.7",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.1",
       "dev": true,
@@ -4082,6 +4110,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5718,6 +5752,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cron": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.7.tgz",
+      "integrity": "sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.4.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "license": "MIT",
@@ -6273,6 +6317,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -8298,6 +8343,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/mapped-types": "^2.0.5",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^4.1.0",
     "@nestjs/typeorm": "^10.0.2",
     "@redis/client": "^1.5.16",
     "@types/bcrypt": "^5.0.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,9 +39,11 @@ import { RedisModule } from './features/auth/redis.module';
 import { EventModule } from './features/event/event.module';
 import { AccountModule } from './features/account/account.module';
 import { AccountService } from './features/account/account.service';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],
@@ -100,7 +102,7 @@ import { AccountService } from './features/account/account.service';
     AuthModule,
     RedisModule,
     EventModule,
-    AccountModule
+    AccountModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/features/funding/funding.module.ts
+++ b/src/features/funding/funding.module.ts
@@ -10,13 +10,15 @@ import { GiftService } from '../gift/gift.service';
 import { Gift } from 'src/entities/gift.entity';
 import { Image } from 'src/entities/image.entity';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { FundingTasksService } from './funding.tasks.service';
+import { Notification } from 'src/entities/notification.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Funding, User, Comment, Friend, Gift, Image]),
+    TypeOrmModule.forFeature([Funding, User, Comment, Friend, Gift, Image, Notification]),
   ],
   controllers: [FundingController],
-  providers: [FundingService, GiftService, GiftogetherExceptions],
+  providers: [FundingService, GiftService, GiftogetherExceptions, FundingTasksService],
   exports: [FundingService],
 })
 export class FundingModule {}

--- a/src/features/funding/funding.tasks.service.ts
+++ b/src/features/funding/funding.tasks.service.ts
@@ -39,24 +39,11 @@ export class FundingTasksService {
       },
     });
 
-    // 펀딩들을 순회하며 Notification 생성 여부를 파악 후 FundClose를 emit한다.
-    closedFundings.filter(
-      async (f) =>
-        !(await this.notiRepo.exists({
-          where: { notiType: NotiType.FundClose, subId: f.fundUuid },
-        })),
-    );
 
     for (const f of closedFundings) {
       this.logger.debug(`"${f.fundTitle}" 마감되어 마감 이벤트 발생하겠습니다.`);
       // 내 펀딩 마감 이벤트 발생
       this.eventEmitter.emit('FundClose', f.fundId);
-
-      // 내가 후원한 펀딩 마감 이벤트 발생
-      this.eventEmitter.emit('FundAchieve', {
-        recvId: f.fundUser.userId,
-        subId: f.fundUuid,
-      });
     }
   }
 }

--- a/src/features/funding/funding.tasks.service.ts
+++ b/src/features/funding/funding.tasks.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { And, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
+import { Funding } from 'src/entities/funding.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Notification } from 'src/entities/notification.entity';
+import { NotiType } from 'src/enums/noti-type.enum';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+@Injectable()
+export class FundingTasksService {
+  private readonly logger = new Logger(FundingTasksService.name);
+  constructor(
+    @InjectRepository(Funding)
+    private readonly fundingRepo: Repository<Funding>,
+
+    @InjectRepository(Notification)
+    private readonly notiRepo: Repository<Notification>,
+
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * 매일 자정 마감된 펀딩들에 대하여 FundClose 이벤트를 생성합니다.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleClosedFundings() {
+    const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // 딱 하루 지난 펀딩만 가지고 옵니다.
+    const closedFundings = await this.fundingRepo.find({
+      where: {
+        endAt: And(MoreThanOrEqual(yesterday), LessThan(today)),
+      },
+      relations: {
+        fundUser: true,
+      },
+    });
+
+    // 펀딩들을 순회하며 Notification 생성 여부를 파악 후 FundClose를 emit한다.
+    closedFundings.filter(
+      async (f) =>
+        !(await this.notiRepo.exists({
+          where: { notiType: NotiType.FundClose, subId: f.fundUuid },
+        })),
+    );
+
+    for (const f of closedFundings) {
+      this.logger.debug(`"${f.fundTitle}" 마감되어 마감 이벤트 발생하겠습니다.`);
+      // 내 펀딩 마감 이벤트 발생
+      this.eventEmitter.emit('FundClose', f.fundId);
+
+      // 내가 후원한 펀딩 마감 이벤트 발생
+      this.eventEmitter.emit('FundAchieve', {
+        recvId: f.fundUser.userId,
+        subId: f.fundUuid,
+      });
+    }
+  }
+}


### PR DESCRIPTION
추가된 의존성: `@nestjs/schedule`

참조한 문서: <https://docs.nestjs.com/techniques/task-scheduling>

매일 자정 마감된 펀딩들에 대하여 FundClose 이벤트를 발생시킵니다. 이벤트가 발생한 시점의 전날 펀딩만 가지고 옵니다.