### PR TITLE
feat(ssl): 소셜 로그인 시에 브라우저가 쿠키를 저장하지 못하는 문제 해결 feat. certbot

### DIFF
--- a/src/features/auth/auth.controller.ts
+++ b/src/features/auth/auth.controller.ts
@@ -34,8 +34,8 @@ export class AuthController {
   private cookieOptions = {
     httpOnly: true,
     path: '/',
-    secure: false,
-    sameSite: 'none' as 'none', // 크로스 도메인 요청을 허용하기 위해 none으로 설정
+    secure: true,
+    // sameSite: 'none' as 'none', // 크로스 도메인 요청을 허용하기 위해 none으로 설정
     domain: '.giftogether.co.kr' // 애플리케이션 도메인으로 설정
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ async function bootstrap() {
 
   if (debugOption) {
     nestFactoryOptions.httpsOptions = {
-      key: fs.readFileSync(process.env.SSL_CERTIFICATE_LOCATION),
-      cert: fs.readFileSync(process.env.SSL_KEY_LOCATION),
+      key: fs.readFileSync(process.env.SSL_KEY_LOCATION),
+      cert: fs.readFileSync(process.env.SSL_CERTIFICATE_LOCATION),
     };
   }
   

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,26 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import * as fs from 'fs';
 import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const port = process.env.PORT;
-  const app = await NestFactory.create(AppModule);
+
+  const debugOption = process.env.DEBUG === 'true';
+  const nestFactoryOptions: Record<string, any> = {};
+
+  if (debugOption) {
+    nestFactoryOptions.httpsOptions = {
+      key: fs.readFileSync(process.env.SSL_CERTIFICATE_LOCATION),
+      cert: fs.readFileSync(process.env.SSL_KEY_LOCATION),
+    };
+  }
+  
+  console.log(nestFactoryOptions);
+
+  const app = await NestFactory.create(AppModule, nestFactoryOptions);
+
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.use(cookieParser());
   app.enableCors({


### PR DESCRIPTION
소셜 로그인시 redirect와 set-cookie할때 브라우저가 쿠키를 저장하지 못하는 문제를 해결했습니다. 원인은 FE는 HTTPS를 사용하나 BE가 HTTP를 사용하기 때문이었습니다. 아래 순서대로 BE 서버에 SSL 인증서 적용했습니다

1. [Certbot](https://certbot.eff.org/instructions?ws=other&os=ubuntufocal&tab=standard)을 사용하여 SSL 인증서를 받았습니다.
2. 배포환경의 .env 파일에 DEBUG, SSL_CERTIFICATE_LOCATION, SSL_KEY_LOCATION key-value 쌍 추가했습니다.
3. [nestjs / https](https://docs.nestjs.com/faq/multiple-servers) 문서를 참고하여 Nest Factory 생성시 httpsOptions 추가했습니다. (이때 DEBUG 여부 파악)

## Cookie Options

아래와 같이 쿠키 옵션을 사용하면 됩니다:

```typescript
  private cookieOptions = {
    httpOnly: true,
    path: '/',
    secure: true,
    // sameSite: 'none' as 'none', // 크로스 도메인 요청을 허용하기 위해 none으로 설정
    domain: '.giftogether.co.kr' // 애플리케이션 도메인으로 설정
  };
```

## 결과

www.giftogether.co.kr/login 에서 소셜 로그인 진행시 redirect 돌아오고 나서 개발자 도구의 Application 탭을 캡쳐한 결과입니다. 

<img width="609" alt="cookie" src="https://github.com/user-attachments/assets/3d7f0b2a-e6c7-4206-be18-4706aefe3134">
