### PR TITLE
WISH-275-fix-create-gratitude

### DIFF
--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -52,7 +52,7 @@ export class GratitudeService {
       const images = await this.imgRepo.find({
         where: { imgType: ImageType.Gratitude, subId: grat.gratId },
       });
-      returnImgUrl.push(images.map((i) => i.imgUrl));
+      returnImgUrl.push(...images.map((i) => i.imgUrl));
     }
 
     return new GetGratitudeDto(

--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -72,26 +72,24 @@ export class GratitudeService {
     });
     if (!funding) throw this.g2gException.FundingNotExists;
 
-    const grat = await this.gratitudeRepo.findOne({
+    let grat = await this.gratitudeRepo.findOne({
       where: { gratId: funding.fundId },
     });
     if (grat) throw this.g2gException.GratitudeAlreadyExists;
+
+    grat = new Gratitude(
+      funding.fundId,
+      gratitudeDto.gratTitle,
+      gratitudeDto.gratCont,
+    );
 
     const returnImgUrl = gratitudeDto.gratImg;
 
     if (gratitudeDto.gratImg.length > 0) {
       // 사용자 정의 이미지 제공시,
       // 1. 새 grat 생성 및 저장.
-      // 2. gratId를 subId로 갖는 새 image 생성 및 저장.
-      const insertResult = await this.gratitudeRepo.insert(
-        new Gratitude(
-          funding.fundId,
-          gratitudeDto.gratTitle,
-          gratitudeDto.gratCont,
-        ),
-      );
-
-      const grat = insertResult.generatedMaps[0] as Gratitude;
+      // 2. gratId(=fundId)를 subId로 갖는 새 image 생성 및 저장.
+      this.gratitudeRepo.insert(grat);
 
       this.imgRepo.insert(
         gratitudeDto.gratImg.map(
@@ -106,11 +104,6 @@ export class GratitudeService {
       // 기본 이미지 제공시,
       // 1. defaultImgId를 갖는 새 grat 생성 및 저장.
 
-      const grat = new Gratitude(
-        funding.fundId,
-        gratitudeDto.gratTitle,
-        gratitudeDto.gratCont,
-      );
       grat.defaultImgId = gratitudeDto.defaultImgId!;
 
       this.gratitudeRepo.insert(grat);

--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -41,7 +41,7 @@ export class GratitudeService {
     });
     if (!grat) throw this.g2gException.GratitudeNotExist;
 
-    let returnImgUrl = [];
+    let returnImgUrl: string[] = [];
 
     if (grat.defaultImgId) {
       const img = await this.imgRepo.findOne({


### PR DESCRIPTION
## `Repository.insert`가 리턴하는 `InsertResult` 타입 인스턴스는 엔티티 인스턴스가 아니다.

createGratitude 메서드는 아래 코드를 사용하여 gratitude 레코드를 저장함과 동시에 gratitude 인스턴스를 받아온다.

```typescript
const insertResult = await this.gratitudeRepo.insert(
  new Gratitude(
    funding.fundId,
    gratitudeDto.gratTitle,
    gratitudeDto.gratCont,
  ),
);

const grat = insertResult.generatedMaps[0] as Gratitude;
```

문제는 여기에서 grat 인스턴스는 디버그시 regAt, isDel 만 가지고 있었다. 우리가 원하던 gratId는 없었다.

## Array.push의 인자는 Array를 받으면 flatten을 안해준다.

```typescript
let array = [];
const images = [...];
array.push(images.map((i) => i.imgUrl); // [[...]]
array.push(...images.map((i) => i.imgUrl); // [...]
```

따라서 Spread Syntax `...`를 사용해주어야 한다.