### PR TITLE
WISH-257-comment-auth-guard

### DIFF
--- a/src/entities/comment.entity.ts
+++ b/src/entities/comment.entity.ts
@@ -39,4 +39,8 @@ export class Comment {
 
   @Column('bool', { default: false })
   isDel: boolean;
+
+  constructor(comment: Partial<Comment>) {
+    Object.assign(this, comment);
+  }
 }

--- a/src/enums/error-code.enum.ts
+++ b/src/enums/error-code.enum.ts
@@ -17,6 +17,7 @@ export enum ErrorCode {
   // RollingPaper
 
   // Comment
+  CommentNotFound = "0500",
 
   // Image
   IncorrectImageUrl = '0600',

--- a/src/enums/error-message.enum.ts
+++ b/src/enums/error-message.enum.ts
@@ -17,6 +17,7 @@ export enum ErrorMsg {
   // RollingPaper
 
   // Comment
+  CommentNotFound = "해당 댓글이 존재하지 않습니다.",
 
   // Image
   IncorrectImageUrl = '이미지 URL이 유효하지 않습니다.',

--- a/src/features/comment/comment.controller.ts
+++ b/src/features/comment/comment.controller.ts
@@ -87,15 +87,20 @@ export class CommentController {
 
   /**
    * 댓글 삭제
+   * @permission 해당 댓글 작성자
+   * @param fundUuid Path Param
+   * @param comId Query Param
    */
-  @Delete()
+  @Delete(':fundUuid')
   @UseGuards(JwtAuthGuard)
   async remove(
-    @Query('fundId') fundId: number,
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
     @Query('comId') comId: number,
+    @Req() req: Request,
   ): Promise<CommonResponse> {
+    const user = req.user as Partial<User>;
     return {
-      data: await this.commentService.remove(fundId, comId),
+      data: await this.commentService.remove(user, fundUuid, comId),
     };
   }
 }

--- a/src/features/comment/comment.controller.ts
+++ b/src/features/comment/comment.controller.ts
@@ -61,16 +61,27 @@ export class CommentController {
 
   /**
    * 댓글 수정
+   * @permission 해당 댓글 작성자
+   * @param fundUuid Path Param
+   * @param comId Query Param
+   * @param updateCommentDto 변경될 데이터
    */
-  @Put()
+  @Put(':fundUuid')
   @UseGuards(JwtAuthGuard)
   async update(
-    @Query('fundId') fundId: number,
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
     @Query('comId') comId: number,
     @Body() updateCommentDto: UpdateCommentDto,
+    @Req() req: Request,
   ): Promise<CommonResponse> {
+    const user = req.user as Partial<User>;
     return {
-      data: await this.commentService.update(fundId, comId, updateCommentDto),
+      data: await this.commentService.update(
+        user,
+        fundUuid,
+        comId,
+        updateCommentDto,
+      ),
     };
   }
 

--- a/src/features/comment/comment.controller.ts
+++ b/src/features/comment/comment.controller.ts
@@ -14,12 +14,15 @@ import {
   Put,
   UseGuards,
   ParseUUIDPipe,
+  Req,
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
+import { Request } from 'express';
+import { User } from 'src/entities/user.entity';
 
 @Controller('comment')
 export class CommentController {
@@ -33,9 +36,11 @@ export class CommentController {
   async create(
     @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
     @Body() createCommentDto: CreateCommentDto,
+    @Req() req: Request,
   ): Promise<CommonResponse> {
+    const user = req.user as Partial<User>;
     return {
-      data: await this.commentService.create(fundUuid, createCommentDto),
+      data: await this.commentService.create(user, fundUuid, createCommentDto),
     };
   }
 

--- a/src/features/comment/comment.controller.ts
+++ b/src/features/comment/comment.controller.ts
@@ -12,11 +12,14 @@ import {
   HttpStatus,
   UseFilters,
   Put,
+  UseGuards,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 
 @Controller('comment')
 export class CommentController {
@@ -25,12 +28,14 @@ export class CommentController {
   /**
    * 댓글 생성
    */
-  @Post()
+  @Post(':fundUuid')
+  @UseGuards(JwtAuthGuard)
   async create(
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
     @Body() createCommentDto: CreateCommentDto,
   ): Promise<CommonResponse> {
     return {
-      data: await this.commentService.create(createCommentDto),
+      data: await this.commentService.create(fundUuid, createCommentDto),
     };
   }
 
@@ -39,18 +44,13 @@ export class CommentController {
    * @param fundId 펀딩에 딸린 모든 댓글을 요청한다
    * @returns Comment[]
    */
-  @Get()
-  async findMany(@Query('fundId') fundId: number): Promise<CommonResponse> {
-    Logger.log(`fundId: ${fundId}`);
-    if (!fundId) {
-      throw new HttpException(
-        '`fundId` query is invalid',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
+  @Get(':fundUuid')
+  async findMany(
+    @Param('fundUuid', ParseUUIDPipe) fundUuid: string,
+  ): Promise<CommonResponse> {
     return {
       message: 'success',
-      data: await this.commentService.findMany(fundId),
+      data: await this.commentService.findMany(fundUuid),
     };
   }
 
@@ -58,6 +58,7 @@ export class CommentController {
    * 댓글 수정
    */
   @Put()
+  @UseGuards(JwtAuthGuard)
   async update(
     @Query('fundId') fundId: number,
     @Query('comId') comId: number,
@@ -72,6 +73,7 @@ export class CommentController {
    * 댓글 삭제
    */
   @Delete()
+  @UseGuards(JwtAuthGuard)
   async remove(
     @Query('fundId') fundId: number,
     @Query('comId') comId: number,

--- a/src/features/comment/comment.module.ts
+++ b/src/features/comment/comment.module.ts
@@ -9,10 +9,11 @@ import { AuthModule } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { JwtService } from '@nestjs/jwt';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { ValidCheck } from 'src/util/valid-check';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Funding, User, Comment]), AuthModule],
   controllers: [CommentController],
-  providers: [CommentService, JwtService, GiftogetherExceptions],
+  providers: [CommentService, JwtService, GiftogetherExceptions, ValidCheck],
 })
 export class CommentModule {}

--- a/src/features/comment/comment.module.ts
+++ b/src/features/comment/comment.module.ts
@@ -5,10 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Funding } from 'src/entities/funding.entity';
 import { User } from 'src/entities/user.entity';
 import { Comment } from 'src/entities/comment.entity';
+import { AuthModule } from '../auth/auth.module';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
+import { JwtService } from '@nestjs/jwt';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Funding, User, Comment])],
+  imports: [TypeOrmModule.forFeature([Funding, User, Comment]), AuthModule],
   controllers: [CommentController],
-  providers: [CommentService],
+  providers: [CommentService, JwtService],
 })
 export class CommentModule {}

--- a/src/features/comment/comment.module.ts
+++ b/src/features/comment/comment.module.ts
@@ -8,10 +8,11 @@ import { Comment } from 'src/entities/comment.entity';
 import { AuthModule } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { JwtService } from '@nestjs/jwt';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Funding, User, Comment]), AuthModule],
   controllers: [CommentController],
-  providers: [CommentService, JwtService],
+  providers: [CommentService, JwtService, GiftogetherExceptions],
 })
 export class CommentModule {}

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -11,14 +11,8 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 
 function convertToGetCommentDto(comment: Comment): GetCommentDto {
   const { comId, content, regAt, isMod, authorId, author } = comment;
-  return {
-    comId,
-    content,
-    regAt,
-    isMod,
-    authorId,
-    authorName: author ? author.userName : '',
-  } as GetCommentDto;
+  const authorName = author?.userName ?? 'ANONYMOUS';
+  return new GetCommentDto(comId, content, regAt, isMod, authorId, authorName);
 }
 
 @Injectable()
@@ -30,10 +24,13 @@ export class CommentService {
     private eventEmitter: EventEmitter2,
   ) {}
 
-  async create(createCommentDto: CreateCommentDto): Promise<GetCommentDto> {
-    let { fundId, authorId, content } = createCommentDto;
+  async create(
+    fundUuid: string,
+    createCommentDto: CreateCommentDto,
+  ): Promise<GetCommentDto> {
+    let { authorId, content } = createCommentDto;
 
-    const where = { fundId };
+    const where = { fundUuid };
     const funding = await this.fundingRepository.findOne({ where });
     if (!funding) {
       throw new HttpException('funding does not exist', HttpStatus.NOT_FOUND);
@@ -45,31 +42,42 @@ export class CommentService {
       throw new HttpException('author does not exist', HttpStatus.NOT_FOUND);
     }
 
-    let newComment: Comment = new Comment();
-    newComment.funding = funding;
-    newComment.fundId = fundId;
-    newComment.author = author;
-    newComment.authorId = authorId;
-    newComment.content = content;
+    const newComment = new Comment({
+      funding,
+      fundId: funding.fundId,
+      author,
+      authorId: author.userId,
+      content,
+    });
 
     await this.commentRepository.save(newComment);
 
-    this.eventEmitter.emit('NewComment', { fundId, authorId });
+    this.eventEmitter.emit('NewComment', { fundId: funding.fundId, authorId });
 
     return convertToGetCommentDto(newComment);
   }
 
   /**
    * 연관 펀딩에 달린 모든 삭제되지 않은 댓글들을 반환한다.
-   * @param fundId comId가 아닌, 펀딩Id라는 점 유의.
+   * @param fundUuid
    * @returns Comment[]
    */
-  async findMany(fundId: number): Promise<GetCommentDto[]> {
-    const where = { funding: { fundId } };
+  async findMany(fundUuid: string): Promise<GetCommentDto[]> {
+    const funding = await this.fundingRepository.findOne({
+      where: { fundUuid },
+      relations: {
+        comments: {
+          author: true,
+        },
+      },
+      order: {
+        comments: {
+          regAt: 'DESC',
+        },
+      },
+    });
 
-    return this.commentRepository
-      .find({ where, relations: { author: true }, order: { regAt: 'DESC' } })
-      .then((comments) => comments.map(convertToGetCommentDto));
+    return funding.comments.map(convertToGetCommentDto);
   }
 
   async update(

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -120,7 +120,7 @@ export class CommentService {
   async remove(user: Partial<User>, fundUuid: string, comId: number) {
     const comment = await this.commentRepository.findOne({
       relations: { funding: true, author: true },
-      where: { comId, funding: { fundUuid } },
+      where: { comId, funding: { fundUuid }, isDel: false },
     });
     if (!comment) {
       throw this.g2gException.CommentNotFound;

--- a/src/features/comment/dto/create-comment.dto.ts
+++ b/src/features/comment/dto/create-comment.dto.ts
@@ -1,5 +1,4 @@
 export class CreateCommentDto {
-  fundId: number;
   authorId: number;
   content: string;
 }

--- a/src/features/comment/dto/create-comment.dto.ts
+++ b/src/features/comment/dto/create-comment.dto.ts
@@ -1,4 +1,3 @@
 export class CreateCommentDto {
-  authorId: number;
   content: string;
 }

--- a/src/features/comment/dto/get-comment.dto.ts
+++ b/src/features/comment/dto/get-comment.dto.ts
@@ -1,8 +1,10 @@
 export class GetCommentDto {
-  comId: Number;
-  content: string;
-  regAt: Date;
-  isMod: boolean;
-  authorId: number;
-  authorName: string;
+  constructor(
+    public comId: Number,
+    public content: string,
+    public regAt: Date,
+    public isMod: boolean,
+    public authorId: number,
+    public authorName: string,
+  ) {}
 }

--- a/src/filters/giftogether-exception.ts
+++ b/src/filters/giftogether-exception.ts
@@ -46,8 +46,8 @@ export class GiftogetherExceptions {
   GiftNotFound = new GiftogetherException(
     ErrorMsg.GiftNotFound,
     ErrorCode.GiftNotFound,
-    HttpStatus.NOT_FOUND
-  )
+    HttpStatus.NOT_FOUND,
+  );
 
   // Gratitude
   GratitudeAlreadyExists = new GiftogetherException(
@@ -64,6 +64,11 @@ export class GiftogetherExceptions {
   // RollingPaper
 
   // Comment
+  CommentNotFound = new GiftogetherException(
+    ErrorMsg.CommentNotFound,
+    ErrorCode.CommentNotFound,
+    HttpStatus.NOT_FOUND,
+  );
 
   // Image
   IncorrectImageUrl = new GiftogetherException(
@@ -94,23 +99,23 @@ export class GiftogetherExceptions {
   NotValidEmail = new GiftogetherException(
     ErrorMsg.NotValidEmail,
     ErrorCode.NotValidEmail,
-    HttpStatus.BAD_REQUEST
-  )
+    HttpStatus.BAD_REQUEST,
+  );
   NotValidPhone = new GiftogetherException(
     ErrorMsg.NotValidPhone,
     ErrorCode.NotValidPhone,
-    HttpStatus.BAD_REQUEST
-  )
+    HttpStatus.BAD_REQUEST,
+  );
   NotValidNick = new GiftogetherException(
     ErrorMsg.NotValidNick,
     ErrorCode.NotValidNick,
-    HttpStatus.BAD_REQUEST
-  )
+    HttpStatus.BAD_REQUEST,
+  );
   PasswordIncorrect = new GiftogetherException(
     ErrorMsg.PasswordIncorrect,
     ErrorCode.PasswordIncorrect,
-    HttpStatus.UNAUTHORIZED 
-  )
+    HttpStatus.UNAUTHORIZED,
+  );
 
   UserFailedToCreate = new GiftogetherException(
     ErrorMsg.UserFailedToCreate,
@@ -121,10 +126,8 @@ export class GiftogetherExceptions {
   UserAccessDenied = new GiftogetherException(
     ErrorMsg.UserAccessDenied,
     ErrorCode.UserAccessDenied,
-    HttpStatus.NOT_FOUND
+    HttpStatus.NOT_FOUND,
   );
-
-
 
   // Friend
   AlreadySendRequest = new GiftogetherException(
@@ -142,8 +145,8 @@ export class GiftogetherExceptions {
   WrongNotiType = new GiftogetherException(
     ErrorMsg.WrongNotiType,
     ErrorCode.WrongNotiType,
-    HttpStatus.BAD_REQUEST
-  )
+    HttpStatus.BAD_REQUEST,
+  );
 
   // Auth
   JwtNotExpired = new GiftogetherException(
@@ -199,12 +202,12 @@ export class GiftogetherExceptions {
     ErrorMsg.AccountNotFound,
     ErrorCode.AccountNotFound,
     HttpStatus.NOT_FOUND,
-  )
+  );
 
   // Address
   AddressNotFound = new GiftogetherException(
     ErrorMsg.AddressNotFound,
     ErrorCode.AddressNotFound,
-    HttpStatus.NOT_FOUND
-  )
+    HttpStatus.NOT_FOUND,
+  );
 }


### PR DESCRIPTION
# Done

Comment API를 최신화 하고 Auth Guard를 붙여 로그인 된 유저만 댓글을 CUD 할 수 있게 했습니다. 본인이 쓴 댓글만 Update Delete 할 수 있게 만들었습니다. 

## `/comment/{fundUuid}` GET 예시

<img width="860" alt="Screenshot 2024-08-27 at 00 59 49" src="https://github.com/user-attachments/assets/c149ed9c-d513-4d76-80c6-272dde1c4a12">

## `/comment/{fundUuid}` POST 예시

<img width="849" alt="Screenshot 2024-08-27 at 01 00 00" src="https://github.com/user-attachments/assets/0ba3e70d-4669-4120-814f-1fc111cd0d60">
