### PR TITLE
Hotfix(comment) Null 참조 에러

### DIFF
--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -85,7 +85,7 @@ export class CommentService {
       },
     });
 
-    return funding.comments.map(convertToGetCommentDto);
+    return funding.comments?.map(convertToGetCommentDto) ?? [];
   }
 
   async update(

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -86,7 +86,7 @@ export class CommentService {
       throw this.g2gException.FundingNotExists;
     }
 
-    return funding.comments?.map(convertToGetCommentDto) ?? [];
+    return funding?.comments.map(convertToGetCommentDto) ?? [];
   }
 
   async update(

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -71,19 +71,17 @@ export class CommentService {
    * @returns Comment[]
    */
   async findMany(fundUuid: string): Promise<GetCommentDto[]> {
-    const funding = await this.fundingRepository.findOne({
-      where: { fundUuid, comments: { isDel: false } },
-      relations: {
-        comments: {
-          author: true,
-        },
-      },
-      order: {
-        comments: {
-          regAt: 'DESC',
-        },
-      },
-    });
+    const funding = await this.fundingRepository
+      .createQueryBuilder('funding')
+      .leftJoinAndSelect(
+        'funding.comments',
+        'comment',
+        'comment.isDel = :isDel',
+        { isDel: false },
+      )
+      .where('funding.fundUuid = :fundUuid', { fundUuid })
+      .orderBy('funding.regAt', 'DESC')
+      .getOne();
 
     return funding.comments?.map(convertToGetCommentDto) ?? [];
   }

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -82,6 +82,9 @@ export class CommentService {
       .where('funding.fundUuid = :fundUuid', { fundUuid })
       .orderBy('funding.regAt', 'DESC')
       .getOne();
+    if (!funding) {
+      throw this.g2gException.FundingNotExists;
+    }
 
     return funding.comments?.map(convertToGetCommentDto) ?? [];
   }

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -80,7 +80,7 @@ export class CommentService {
         { isDel: false },
       )
       .where('funding.fundUuid = :fundUuid', { fundUuid })
-      .orderBy('funding.regAt', 'DESC')
+      .orderBy('comment.regAt', 'DESC')
       .getOne();
     if (!funding) {
       throw this.g2gException.FundingNotExists;


### PR DESCRIPTION
funding이 null인데 comments 프로퍼티를 찾으려고 했기 때문입니다. 따라서 ?. 연산자를 사용하여 자동으로 null로 fallback 하고 뒤에 ?? 연산자를 사용하여 빈 배열을 반환하도록 바꿨습니다

```typescript
funding?.comments.map(convertToGetCommentDto) ?? [];
```

쿼리빌더를 사용하여 funding과 comment를 조인하는데 `comment.isDel`이 false인 comment만 가지고 오도록 수정했습니다.

이전 코드에서는 `funding`이 null이 되는 경우가 있었는데, 쿼리를 잘못 짜 "모든 `comment.isDel`이 반드시 false여야 하는" 경우였습니다. 추가적으로 funding이 실제로 존재하지 않은 경우 에러를 throw 하도록 코드를 추가했습니다.

> 예시 응답

```json
{
    "timestamp": "2024-08-31T23:24:47.444Z",
    "message": "success",
    "data": [
        {
            "comId": 39,
            "content": "Quam et labore beatae aut qui. Sint non officiis non aut natus ut. Vero repellendus et veniam sint nobis assumenda quis recusandae earum. Non architecto doloribus praesentium itaque magnam et. Adipisci omnis eius et necessitatibus quo cumque quos voluptas.",
            "regAt": "2024-08-31T05:09:04.618Z",
            "isMod": false,
            "authorId": 140,
            "authorName": "ANONYMOUS"
        },
        {
            "comId": 38,
            "content": "Numquam porro reiciendis sit debitis. Ex consequatur et expedita est nihil omnis totam minima. Exercitationem molestiae voluptatem qui cum illum temporibus aut temporibus.",
            "regAt": "2024-08-27T05:15:56.004Z",
            "isMod": false,
            "authorId": 140,
            "authorName": "ANONYMOUS"
        },
        {
            "comId": 37,
            "content": "Eos doloremque consequuntur suscipit repudiandae occaecati sapiente. Reprehenderit iure fugit. Quia et quia eius eligendi eos.",
            "regAt": "2024-08-27T05:15:30.524Z",
            "isMod": false,
            "authorId": 140,
            "authorName": "ANONYMOUS"
        }
    ]
}
```