### PR TITLE
✨ feat(image): Add auth guard to uploadFiles

### DIFF
--- a/src/features/image/image.module.ts
+++ b/src/features/image/image.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ImageController } from './image.controller';
 import { ImageService } from './image.service';
+import { AuthModule } from '../auth/auth.module';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 
 @Module({
-  imports: [],
+  imports: [AuthModule],
   controllers: [ImageController],
-  providers: [ImageService],
+  providers: [ImageService, JwtAuthGuard, GiftogetherExceptions],
 })
 export class ImageModule {}


### PR DESCRIPTION
제목이 전부 설명을 합니다. 이젠 Authorization 헤더에 액세스 토큰이 담겨야 이미지 업로드가 가능합니다.

## 주의

회원가입시 프로필 이미지를 기본 이미지로 설정한 뒤 프로필 페이지에 가서 이미지를 변경하거나 `/signup/extra`에 가서 이미지를 변경하는 방법말고는 없을 것 같습니다.