### PR TITLE
WISH-285-image-deletion

### DIFF
--- a/src/entities/gift.entity.ts
+++ b/src/entities/gift.entity.ts
@@ -31,10 +31,6 @@ export class Gift {
   @Column({ nullable: true })
   giftCont: string;
 
-  @OneToOne(() => Image, (image) => image.subId, { nullable: true })
-  // @JoinColumn({ name: 'imgId' })
-  image: Image;
-
   @Column({ nullable: true })
   @ManyToOne(() => Image, (image) => image.imgId)
   defaultImgId?: number;

--- a/src/enums/error-code.enum.ts
+++ b/src/enums/error-code.enum.ts
@@ -21,6 +21,9 @@ export enum ErrorCode {
 
   // Image
   IncorrectImageUrl = '0600',
+  IncorrectImageHost = '0601',
+  ImageUriNotSpecified = '0602',
+  ImageNotFound = '0603',
 
   // User
   UserNotFound = '0700',

--- a/src/enums/error-message.enum.ts
+++ b/src/enums/error-message.enum.ts
@@ -21,6 +21,9 @@ export enum ErrorMsg {
 
   // Image
   IncorrectImageUrl = '이미지 URL이 유효하지 않습니다.',
+  IncorrectImageHost = '이미지 호스트가 일치하지 않습니다.',
+  ImageUriNotSpecified = '이미지 URI가 유효하지 않습니다.',
+  ImageNotFound = '이미지가 존재하지 않습니다.',
 
   // User
   UserNotFound = '사용자 정보가 없습니다.',

--- a/src/features/funding/funding.module.ts
+++ b/src/features/funding/funding.module.ts
@@ -18,14 +18,36 @@ import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { RollingPaperService } from '../rolling-paper/rolling-paper.service';
 import { ValidCheck } from 'src/util/valid-check';
 import { AuthModule } from '../auth/auth.module';
+import { ImageService } from '../image/image.service';
+import { S3Service } from '../image/s3.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Funding, User, Comment, Friend, Gift, Image, Notification, Donation, RollingPaper]),
-    AuthModule
+    TypeOrmModule.forFeature([
+      Funding,
+      User,
+      Comment,
+      Friend,
+      Gift,
+      Image,
+      Notification,
+      Donation,
+      RollingPaper,
+    ]),
+    AuthModule,
   ],
   controllers: [FundingController],
-  providers: [FundingService, GiftService, DonationService, RollingPaperService, GiftogetherExceptions, FundingTasksService, ValidCheck],
+  providers: [
+    FundingService,
+    GiftService,
+    DonationService,
+    RollingPaperService,
+    GiftogetherExceptions,
+    FundingTasksService,
+    ValidCheck,
+    ImageService,
+    S3Service,
+  ],
   exports: [FundingService],
 })
 export class FundingModule {}

--- a/src/features/funding/funding.service.ts
+++ b/src/features/funding/funding.service.ts
@@ -39,7 +39,7 @@ export class FundingService {
     private readonly g2gException: GiftogetherExceptions,
 
     private readonly validCheck: ValidCheck,
-  ) {}
+  ) { }
 
   async findFundingByUuidAndUserId(
     fundUuid: string,
@@ -421,10 +421,7 @@ export class FundingService {
     await this.imgService.delete(ImageType.Funding, funding.fundId);
     // 선물과 연관된 이미지를 unlink하고 삭제한다.
     const gifts = funding.gifts;
-    const deleteGiftPromises = gifts.map(async (g) =>
-      this.giftService.deleteGift(g.giftId),
-    );
-    await Promise.all(deleteGiftPromises);
+    await this.giftService.delete(...gifts);
     this.fundingRepository.remove(funding);
   }
 }

--- a/src/features/funding/funding.service.ts
+++ b/src/features/funding/funding.service.ts
@@ -418,6 +418,8 @@ export class FundingService {
   async remove(fundUuid: string, userId: number): Promise<void> {
     const funding = await this.findFundingByUuidAndUserId(fundUuid, userId);
     // 펀딩과 연관된 이미지를 unlink하고 삭제한다.
+    await this.imgService.delete(ImageType.Funding, funding.fundId);
+    // 선물과 연관된 이미지를 unlink하고 삭제한다.
     const gifts = funding.gifts;
     const deleteGiftPromises = gifts.map(async (g) =>
       this.giftService.deleteGift(g.giftId),

--- a/src/features/gift/gift.module.ts
+++ b/src/features/gift/gift.module.ts
@@ -6,11 +6,13 @@ import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { Gift } from 'src/entities/gift.entity';
 import { Funding } from 'src/entities/funding.entity';
 import { Image } from 'src/entities/image.entity';
+import { ImageModule } from '../image/image.module';
+import { ImageService } from '../image/image.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Gift, Funding, Image])],
+  imports: [TypeOrmModule.forFeature([Gift, Funding, Image]), ImageModule],
   controllers: [GiftController],
-  providers: [GiftService, GiftogetherExceptions],
+  providers: [GiftService, GiftogetherExceptions, ImageService],
   exports: [GiftService],
 })
 export class GiftModule {}

--- a/src/features/gift/gift.service.ts
+++ b/src/features/gift/gift.service.ts
@@ -29,7 +29,7 @@ export class GiftService {
     private readonly g2gException: GiftogetherExceptions,
 
     private readonly imgService: ImageService,
-  ) {}
+  ) { }
 
   async findAllGift(fund: Funding): Promise<{
     gifts: ResponseGiftDto[];
@@ -224,6 +224,14 @@ export class GiftService {
 
     await this.giftRepository.save(gift);
     return defaultImage.imgUrl;
+  }
+
+  async delete(...gifts: Gift[]): Promise<Gift[]> {
+    const deleteImgPromises = gifts.map(async (g) =>
+      this.imgService.delete(ImageType.Gift, g.giftId),
+    );
+    Promise.all(deleteImgPromises);
+    return this.giftRepository.remove(gifts);
   }
 
   private async deleteGift(

--- a/src/features/gift/gift.service.ts
+++ b/src/features/gift/gift.service.ts
@@ -182,10 +182,7 @@ export class GiftService {
       return defaultImage.imgUrl;
     } else {
       // 기본 이미지가 설정되어 있지 않다면 기존 이미지를 삭제하고 기본 이미지를 설정
-      await this.imgRepository.delete({
-        imgType: ImageType.Gift,
-        subId: existGift.giftId,
-      });
+      await this.imgService.delete(ImageType.Gift, existGift.giftId);
 
       return this.setDefaultGiftImage(existGift);
     }

--- a/src/features/image/dto/image.dto.ts
+++ b/src/features/image/dto/image.dto.ts
@@ -1,3 +1,6 @@
+import { IsUrl } from 'class-validator';
+
 export class ImageDto {
+  @IsUrl({}, { each: true })
   urls: string[];
 }

--- a/src/features/image/dto/url.dto.ts
+++ b/src/features/image/dto/url.dto.ts
@@ -1,0 +1,6 @@
+import { IsUrl } from 'class-validator';
+
+export class UrlDto {
+  @IsUrl()
+  url: string;
+}

--- a/src/features/image/image.controller.ts
+++ b/src/features/image/image.controller.ts
@@ -10,17 +10,17 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
-import { ImageService } from './image.service';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { ImageDto } from './dto/image.dto';
 import { v4 as uuidv4 } from 'uuid';
 import * as sharp from 'sharp';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { UrlDto } from './dto/url.dto';
+import { S3Service } from './s3.service';
 
 @Controller('image')
 export class ImageController {
-  constructor(private readonly imageService: ImageService) {}
+  constructor(private readonly s3Service: S3Service) {}
 
   @Post()
   @UseInterceptors(FilesInterceptor('files'))
@@ -45,7 +45,7 @@ export class ImageController {
 
       const filename = uuidv4() + '.' + extension;
 
-      const url = await this.imageService.upload(filename, buffer);
+      const url = await this.s3Service.upload(filename, buffer);
       urls.push(url);
     }
 
@@ -69,7 +69,7 @@ export class ImageController {
   async deleteFile(@Body() urlDto: UrlDto): Promise<CommonResponse> {
     const { url } = urlDto;
 
-    await this.imageService.delete(url);
+    await this.s3Service.delete(url);
 
     return {
       message: '성공적으로 파일이 삭제되었습니다.',

--- a/src/features/image/image.controller.ts
+++ b/src/features/image/image.controller.ts
@@ -63,6 +63,7 @@ export class ImageController {
    * S3에 저장된 파일을 포함하여 제거합니다.
    * @authorization JWT Bearer Token
    * @param imgUrl 제거하고자 하는 이미지의 파일 URL
+   * @todo 자신이 올린 이미지를 제외한 파일은 제거하지 못하도록 정책을 추가해야 합니다.
    */
   @Delete()
   @UseGuards(JwtAuthGuard)

--- a/src/features/image/image.controller.ts
+++ b/src/features/image/image.controller.ts
@@ -1,5 +1,7 @@
 import {
+  Body,
   Controller,
+  Delete,
   FileTypeValidator,
   ParseFilePipe,
   Post,
@@ -14,6 +16,7 @@ import { ImageDto } from './dto/image.dto';
 import { v4 as uuidv4 } from 'uuid';
 import * as sharp from 'sharp';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
+import { UrlDto } from './dto/url.dto';
 
 @Controller('image')
 export class ImageController {
@@ -51,6 +54,26 @@ export class ImageController {
     return {
       message: '성공적으로 파일이 업로드 되었습니다.',
       data: uploadedImages,
+    };
+  }
+
+  /**
+   * 파일 URL로부터 파일명을 추출한 다음
+   * 데이터베이스에 저장이 되어있는지 확인한 후
+   * S3에 저장된 파일을 포함하여 제거합니다.
+   * @authorization JWT Bearer Token
+   * @param imgUrl 제거하고자 하는 이미지의 파일 URL
+   */
+  @Delete()
+  @UseGuards(JwtAuthGuard)
+  async deleteFile(@Body() urlDto: UrlDto): Promise<CommonResponse> {
+    const { url } = urlDto;
+
+    await this.imageService.delete(url);
+
+    return {
+      message: '성공적으로 파일이 삭제되었습니다.',
+      data: null,
     };
   }
 }

--- a/src/features/image/image.module.ts
+++ b/src/features/image/image.module.ts
@@ -4,9 +4,11 @@ import { ImageService } from './image.service';
 import { AuthModule } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Image } from 'src/entities/image.entity';
 
 @Module({
-  imports: [AuthModule],
+  imports: [TypeOrmModule.forFeature([Image]), AuthModule],
   controllers: [ImageController],
   providers: [ImageService, JwtAuthGuard, GiftogetherExceptions],
 })

--- a/src/features/image/image.module.ts
+++ b/src/features/image/image.module.ts
@@ -4,11 +4,9 @@ import { ImageService } from './image.service';
 import { AuthModule } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Image } from 'src/entities/image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Image]), AuthModule],
+  imports: [AuthModule],
   controllers: [ImageController],
   providers: [ImageService, JwtAuthGuard, GiftogetherExceptions],
 })

--- a/src/features/image/image.module.ts
+++ b/src/features/image/image.module.ts
@@ -6,10 +6,12 @@ import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Image } from 'src/entities/image.entity';
+import { S3Service } from './s3.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Image]), AuthModule],
   controllers: [ImageController],
-  providers: [ImageService, JwtAuthGuard, GiftogetherExceptions],
+  providers: [ImageService, JwtAuthGuard, GiftogetherExceptions, S3Service],
+  exports: [ImageService, S3Service],
 })
 export class ImageModule {}

--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -7,6 +7,10 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { ImageType } from 'src/enums/image-type.enum';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Image } from 'src/entities/image.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class ImageService {
@@ -17,7 +21,10 @@ export class ImageService {
 
   private readonly bucketName = process.env.AWS_S3_BUCKET_NAME;
 
-  constructor(private readonly g2gException: GiftogetherExceptions) {}
+  constructor(
+    private readonly g2gException: GiftogetherExceptions,
+    @InjectRepository(Image) private readonly imgRepo: Repository<Image>,
+  ) {}
 
   getObjectUrlOf(filename: string): string {
     return `https://${process.env.AWS_S3_BUCKET_NAME}.s3.amazonaws.com/${filename}`;
@@ -35,6 +42,25 @@ export class ImageService {
     return this.getObjectUrlOf(filename);
   }
 
+  /**
+   * Image Table에서 레코드 하나를 제거하는 메서드. ImageService를 Inject하여 사용하세요.
+   * @param imgType 연관 테이블 타입
+   * @param subId FK
+   */
+  async unlink(imgType: ImageType, subId: number) {
+    const image = await this.imgRepo.findOne({
+      where: { imgType, subId },
+    });
+    if (!image) {
+      throw this.g2gException.ImageNotFound;
+    }
+    this.imgRepo.remove(image); // TODO - Soft Delete
+  }
+
+  /**
+   * S3 버킷에 저장된 객체를 삭제합니다.
+   * @param url 삭제하고자 하는 S3 기프투게더 이미지 URL
+   */
   async delete(url: string): Promise<void> {
     const regex = /^(https?):\/\/([^\/]+)\/(.*)?$/;
     const matches = url.match(regex);

--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -1,107 +1,44 @@
 import { Injectable } from '@nestjs/common';
-import {
-  DeleteObjectCommand,
-  HeadObjectCommand,
-  NotFound,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3';
-import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { ImageType } from 'src/enums/image-type.enum';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Image } from 'src/entities/image.entity';
 import { Repository } from 'typeorm';
+import { S3Service } from './s3.service';
+import { GiftogetherException } from 'src/filters/giftogether-exception';
 
 @Injectable()
 export class ImageService {
-  private readonly s3Client = new S3Client({
-    region: process.env.AWS_S3_REGION,
-    maxAttempts: 30,
-  });
-
-  private readonly bucketName = process.env.AWS_S3_BUCKET_NAME;
-
   constructor(
-    private readonly g2gException: GiftogetherExceptions,
+    private readonly s3Service: S3Service,
     @InjectRepository(Image) private readonly imgRepo: Repository<Image>,
   ) {}
 
-  getObjectUrlOf(filename: string): string {
-    return `https://${process.env.AWS_S3_BUCKET_NAME}.s3.amazonaws.com/${filename}`;
-  }
-
-  async upload(filename: string, file: Buffer): Promise<string> {
-    await this.s3Client.send(
-      new PutObjectCommand({
-        Bucket: this.bucketName,
-        Key: filename,
-        Body: file,
-      }),
-    );
-
-    return this.getObjectUrlOf(filename);
+  private async getInstancesBySubId(
+    imgType: ImageType,
+    subId: number,
+  ): Promise<Image[]> {
+    return this.imgRepo.find({
+      where: { imgType, subId },
+    });
   }
 
   /**
-   * Image Table에서 레코드 하나를 제거하는 메서드. ImageService를 Inject하여 사용하세요.
+   * Image Table에서 subId가 일치하는 레코드를 제거하고 S3 delete도 같이 수행합니다.
    * @param imgType 연관 테이블 타입
    * @param subId FK
    */
-  async unlink(imgType: ImageType, subId: number) {
-    const image = await this.imgRepo.findOne({
-      where: { imgType, subId },
+  async delete(imgType: ImageType, subId: number) {
+    const images = await this.getInstancesBySubId(imgType, subId);
+    const removePromises = images.map(async (i) => {
+      return this.s3Service.delete(i.imgUrl);
     });
-    if (!image) {
-      throw this.g2gException.ImageNotFound;
-    }
-    this.imgRepo.remove(image); // TODO - Soft Delete
-  }
-
-  /**
-   * S3 버킷에 저장된 객체를 삭제합니다.
-   * @param url 삭제하고자 하는 S3 기프투게더 이미지 URL
-   */
-  async delete(url: string): Promise<void> {
-    const regex = /^(https?):\/\/([^\/]+)\/(.*)?$/;
-    const matches = url.match(regex);
-
-    if (!matches) {
-      this.g2gException.IncorrectImageUrl;
-    }
-
-    // const protocol = matches[1];
-    const host = matches[2];
-    const uri = matches[3];
-
-    if (host !== process.env.AWS_S3_HOST) {
-      this.g2gException.IncorrectImageUrl;
-    }
-    if (!uri) {
-      this.g2gException.ImageUriNotSpecified;
-    }
-
-    // 파일이 존재하는지 먼저 확인한다.
-    await this.s3Client
-      .send(
-        new HeadObjectCommand({
-          Bucket: this.bucketName,
-          Key: uri,
-        }),
-      )
-      .catch((e) => {
-        if (e instanceof NotFound) {
-          throw this.g2gException.ImageNotFound;
-        }
-        throw e;
-      })
-      .then(() => {
-        // 그리고 마침내 삭제 요청을 보낸다.
-        this.s3Client.send(
-          new DeleteObjectCommand({
-            Bucket: this.bucketName,
-            Key: uri,
-          }),
-        );
-      });
+    await Promise.all(removePromises).catch((e) => {
+      if (e instanceof GiftogetherException) {
+        // do nothing
+        return;
+      }
+      throw e;
+    });
+    this.imgRepo.remove(images);
   }
 }

--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -9,7 +9,6 @@ import { GiftogetherException } from 'src/filters/giftogether-exception';
 @Injectable()
 export class ImageService {
   constructor(
-    private readonly s3Service: S3Service,
     @InjectRepository(Image) private readonly imgRepo: Repository<Image>,
   ) {}
 
@@ -23,22 +22,13 @@ export class ImageService {
   }
 
   /**
-   * Image Table에서 subId가 일치하는 레코드를 제거하고 S3 delete도 같이 수행합니다.
+   * Image Table에서 subId가 일치하는 레코드를 제거한다
    * @param imgType 연관 테이블 타입
    * @param subId FK
+   * @returns 제거된 이미지 인스턴스들
    */
   async delete(imgType: ImageType, subId: number) {
     const images = await this.getInstancesBySubId(imgType, subId);
-    const removePromises = images.map(async (i) => {
-      return this.s3Service.delete(i.imgUrl);
-    });
-    await Promise.all(removePromises).catch((e) => {
-      if (e instanceof GiftogetherException) {
-        // do nothing
-        return;
-      }
-      throw e;
-    });
-    this.imgRepo.remove(images);
+    return this.imgRepo.remove(images);
   }
 }

--- a/src/features/image/s3.service.ts
+++ b/src/features/image/s3.service.ts
@@ -1,0 +1,82 @@
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  NotFound,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class S3Service {
+  constructor(private readonly g2gException: GiftogetherExceptions) {
+    this.s3Client = new S3Client({
+      region: process.env.AWS_S3_REGION,
+      maxAttempts: 30,
+    });
+  }
+  private readonly s3Client: S3Client;
+
+  private readonly bucketName = process.env.AWS_S3_BUCKET_NAME;
+
+  async upload(filename: string, file: Buffer): Promise<string> {
+    await this.s3Client.send(
+      new PutObjectCommand({
+        Bucket: this.bucketName,
+        Key: filename,
+        Body: file,
+      }),
+    );
+
+    return `https://${process.env['AWS_S3_HOST']}/${filename}`;
+  }
+
+  /**
+   * S3 버킷에 저장된 객체를 삭제합니다.
+   * @param url 삭제하고자 하는 S3 기프투게더 이미지 URL
+   */
+  async delete(url: string): Promise<void> {
+    const regex = /^(https?):\/\/([^\/]+)\/(.*)?$/;
+    const matches = url.match(regex);
+
+    if (!matches || matches.length !== 4) {
+      throw this.g2gException.IncorrectImageUrl;
+    }
+
+    // const protocol = matches[1];
+    const host = matches[2];
+    const uri = matches[3];
+
+    if (host !== process.env.AWS_S3_HOST) {
+      this.g2gException.IncorrectImageUrl;
+    }
+    if (!uri) {
+      this.g2gException.ImageUriNotSpecified;
+    }
+
+    // 파일이 존재하는지 먼저 확인한다.
+    await this.s3Client
+      .send(
+        new HeadObjectCommand({
+          Bucket: this.bucketName,
+          Key: uri,
+        }),
+      )
+      .catch((e) => {
+        if (e instanceof NotFound) {
+          throw this.g2gException.ImageNotFound;
+        }
+        throw e;
+      })
+      .then(() => {
+        // 그리고 마침내 삭제 요청을 보낸다.
+        this.s3Client.send(
+          new DeleteObjectCommand({
+            Bucket: this.bucketName,
+            Key: uri,
+          }),
+        );
+      });
+  }
+}

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -19,14 +19,37 @@ import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { RollingPaperService } from '../rolling-paper/rolling-paper.service';
 import { ValidCheck } from 'src/util/valid-check';
 import { AuthModule } from '../auth/auth.module';
+import { ImageService } from '../image/image.service';
+import { S3Service } from '../image/s3.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Account, Image, Address, Funding, Friend, Gift, Donation, RollingPaper]),
-    AuthModule
+    TypeOrmModule.forFeature([
+      User,
+      Account,
+      Image,
+      Address,
+      Funding,
+      Friend,
+      Gift,
+      Donation,
+      RollingPaper,
+    ]),
+    AuthModule,
   ],
   controllers: [UserController],
-  providers: [UserService, AddressService, FundingService, GiftService, DonationService, RollingPaperService, GiftogetherExceptions, ValidCheck],
+  providers: [
+    UserService,
+    AddressService,
+    FundingService,
+    GiftService,
+    DonationService,
+    RollingPaperService,
+    GiftogetherExceptions,
+    ValidCheck,
+    ImageService,
+    S3Service,
+  ],
   exports: [UserService],
 })
 export class UserModule {}

--- a/src/filters/giftogether-exception.ts
+++ b/src/filters/giftogether-exception.ts
@@ -77,6 +77,23 @@ export class GiftogetherExceptions {
     HttpStatus.BAD_REQUEST,
   );
 
+  IncorrectImageHost = new GiftogetherException(
+    ErrorMsg.IncorrectImageHost,
+    ErrorCode.IncorrectImageHost,
+    HttpStatus.BAD_REQUEST,
+  );
+
+  ImageUriNotSpecified = new GiftogetherException(
+    ErrorMsg.ImageUriNotSpecified,
+    ErrorCode.ImageUriNotSpecified,
+    HttpStatus.BAD_REQUEST,
+  );
+
+  ImageNotFound = new GiftogetherException(
+    ErrorMsg.ImageNotFound,
+    ErrorCode.ImageNotFound,
+    HttpStatus.NOT_FOUND,
+  );
   // User
   UserNotFound = new GiftogetherException(
     ErrorMsg.UserNotFound,


### PR DESCRIPTION
## Image 삭제 API

- 현재 인증된 모든 유저는 이미지 URL만 안다면 S3 객체를 삭제할 권한을 가지고 있습니다. ⇒ Image 테이블에 userId 컬럼을 추가하는 기능을 구현할 예정입니다.
- 이미지 테이블에 이미지를 제거하는 `ImageService.delete` 메서드를 작성했습니다. 리소스 삭제시 연쇄적으로 Image 레코드를 제거하고 싶다면 이 메서드를 주입하여 사용하세요.

## 욕심을 내보자면...

이미지 생성 후 연관 리소스와 관계를 생성하는 기능을 추가할수도.. `link` 메서드를 사용하면 될 듯 하다.

## 이미지 제거 예시

이미지가 S3에 존재하지 않는 경우 => 404

<img width="1507" alt="Screenshot 2024-09-03 at 01 49 16" src="https://github.com/user-attachments/assets/ec9a907e-8d4e-4c82-bc8e-9db6f46d5a2a">

이미지가 S3에 존재하는 경우 => 200

<img width="1507" alt="Screenshot 2024-09-03 at 01 49 12" src="https://github.com/user-attachments/assets/fa4dce78-5bb4-4698-a026-6bdc9b9baa1a">


## `ImageService.delete` 사용사례

FundingService.remove에서 이미지를 unlink 하고 delete하는 코드를 추가했습니다.


```typescript
    await this.imgService.delete(ImageType.Funding, funding.fundId);
```

## gift.service 메서드 추가

`delete` 퍼블릭 메서드를 추가하여 funding.service.delete에서 이를 사용합니다.

```typescript
  async delete(...gifts: Gift[]): Promise<Gift[]> {
    const deleteImgPromises = gifts.map(async (g) =>
      this.imgService.delete(ImageType.Gift, g.giftId),
    );
    Promise.all(deleteImgPromises);
    return this.giftRepository.remove(gifts);
  }
```

## 테스트 결과

**[펀딩 생성시]**

funding과 연관 gift들:

![Screenshot From 2024-09-22 01-58-36](https://github.com/user-attachments/assets/5667b3c9-87f5-4907-8fc6-8edba8b8e71b)

각 gift에 연관된 image들:

![Screenshot From 2024-09-22 01-59-21](https://github.com/user-attachments/assets/009a6ad9-9347-42fa-85c3-868ef74c62b6)

**[펀딩 삭제시]**

해당 항목의 이미지 레코드가 삭제되어있는 것을 볼 수 있음.

![Screenshot From 2024-09-22 02-00-37](https://github.com/user-attachments/assets/7a872c8b-9c68-467c-90a9-dba1500bd874)
