### PR TITLE
feat(gift): add deleteGift in createOrUpdateGift WISH-289

### DIFF
--- a/src/features/gift/gift.controller.ts
+++ b/src/features/gift/gift.controller.ts
@@ -45,16 +45,16 @@ export class GiftController {
   //   }
   // }
 
-  @Delete(':giftId')
-  async deleteGift(
-    @Param('giftId', ParseIntPipe) giftId: number,
-  ): Promise<CommonResponse> {
-    try {
-      return {
-        data: await this.giftService.deleteGift(giftId),
-      };
-    } catch (error) {
-      throw error;
-    }
-  }
+  // @Delete(':giftId')
+  // async deleteGift(
+  //   @Param('giftId', ParseIntPipe) giftId: number,
+  // ): Promise<CommonResponse> {
+  //   try {
+  //     return {
+  //       data: await this.giftService.deleteGift(giftId),
+  //     };
+  //   } catch (error) {
+  //     throw error;
+  //   }
+  // }
 }


### PR DESCRIPTION
**createOrUpdateGift 요청 시, 기존 funding과 연결된 Gift들 중 RequestGiftDto[]에서 없어진 Gift는 삭제되도록 로직 추가**

1. 기존 Funding에 연결된 모든 Gift 조회
```typescript
    // 기존 Funding에 연결된 모든 Gift 조회
    const existingGifts = await this.giftRepository.find({
      where: { funding: { fundId: funding.fundId } },
    });

    // 삭제할 Gift를 추적하기 위한 Set
    const existingGiftIds = new Set(existingGifts.map(gift => gift.giftId));
```
2. 요청된 Gift 목록을 업데이트하거나 새로운 Gift를 추가하기 위해 gifts를 순회하면서 요청으로 들어온 Gift의 giftId 목록 추출
```typescript
    // 요청된 Gift 목록을 순회하면서 업데이트하거나 새로운 Gift를 추가
    const resultGifts = await Promise.all(
      gifts.map(async (gift) => {
        if (gift.giftId) {
          // giftId가 존재하면 기존 Gift를 업데이트
          const updatedGift = await this.updateGift(funding, gift);
          existingGiftIds.delete(gift.giftId); // 업데이트된 Gift는 삭제 대상에서 제외
          return updatedGift;
        } else {
          // giftId가 없으면 새로운 Gift 생성
          const newGift = await this.createNewGift(funding, gift);
          return newGift;
        }
      })
    );
```
3. 삭제할 Gift 목록 추출
```typescript
    const giftsToDelete = existingGifts.filter(
      existingGift => existingGiftIds.has(existingGift.giftId)
    );
``` 
4. 삭제할 Gift들을 데이터베이스에서 제거

```typescript
    // 삭제할 Gift 제거
    if (giftsToDelete.length > 0) {
      await this.giftRepository.remove(giftsToDelete);
    }
``` 