### PR TITLE
WISH-303-Image-User-Relational-Mapping

### DIFF
--- a/src/entities/image.entity.ts
+++ b/src/entities/image.entity.ts
@@ -22,16 +22,16 @@ export class Image {
     enum: ImageType,
     nullable: true,
   })
-  imgType: ImageType;
+  imgType?: ImageType;
 
   @Index({ unique: false })
   @Column('int', { nullable: true })
-  subId: number;
+  subId?: number;
 
   @ManyToOne(() => User, (user) => user.createdImages)
   creator: User;
 
-  constructor(imgUrl: string, imgType: ImageType, subId: number) {
+  constructor(imgUrl: string, imgType?: ImageType, subId?: number) {
     this.imgUrl = imgUrl;
     this.imgType = imgType;
     this.subId = subId;

--- a/src/entities/image.entity.ts
+++ b/src/entities/image.entity.ts
@@ -20,6 +20,7 @@ export class Image {
   @Column({
     type: 'enum',
     enum: ImageType,
+    nullable: true,
   })
   imgType: ImageType;
 

--- a/src/entities/image.entity.ts
+++ b/src/entities/image.entity.ts
@@ -4,9 +4,9 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Index,
-  OneToOne,
+  ManyToOne,
 } from 'typeorm';
-import { Gratitude } from './gratitude.entity';
+import { User } from './user.entity';
 
 @Entity()
 export class Image {
@@ -26,6 +26,9 @@ export class Image {
   @Index({ unique: false })
   @Column('int', { nullable: true })
   subId: number;
+
+  @ManyToOne(() => User, (user) => user.createdImages)
+  creator: User;
 
   constructor(imgUrl: string, imgType: ImageType, subId: number) {
     this.imgUrl = imgUrl;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -45,7 +45,10 @@ export class User {
   @Column('date', { nullable: true })
   userBirth: Date;
 
-  @OneToOne(() => Account, (account) => account.user, { nullable: true, onDelete: 'SET NULL' })
+  @OneToOne(() => Account, (account) => account.user, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'userAcc' })
   account: Account;
 
@@ -71,6 +74,9 @@ export class User {
   @Column('int', { nullable: true })
   @OneToOne(() => Image, (image) => image.imgId)
   defaultImgId?: number;
+
+  @OneToMany(() => Image, (image) => image.creator)
+  createdImages: Image[];
 
   /**
    * defaultImgId가 NULL일 경우, Image.subId로 조회할 수 있습니다.

--- a/src/features/image/image.module.ts
+++ b/src/features/image/image.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ImageController } from './image.controller';
+import { ImageController } from './image2.controller';
 import { ImageService } from './image.service';
 import { AuthModule } from '../auth/auth.module';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';

--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -3,8 +3,7 @@ import { ImageType } from 'src/enums/image-type.enum';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Image } from 'src/entities/image.entity';
 import { Repository } from 'typeorm';
-import { S3Service } from './s3.service';
-import { GiftogetherException } from 'src/filters/giftogether-exception';
+import { User } from 'src/entities/user.entity';
 
 @Injectable()
 export class ImageService {
@@ -30,5 +29,17 @@ export class ImageService {
   async delete(imgType: ImageType, subId: number) {
     const images = await this.getInstancesBySubId(imgType, subId);
     return this.imgRepo.remove(images);
+  }
+
+  /**
+   * Image Table에서 URL이 일치하는 레코드를 제거한다.
+   * @note 이 메서드는 컨트롤러에서 인가 작업이 완료가 된 다음 호출해야 안전합니다.
+   */
+  async deleteByUrlAndUser(imgUrl: string, creator: User) {
+    const image = await this.imgRepo.findOneOrFail({
+      where: { imgUrl, creator },
+    });
+
+    return this.imgRepo.remove(image);
   }
 }

--- a/src/features/image/image2.controller.ts
+++ b/src/features/image/image2.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  FileTypeValidator,
+  ParseFilePipe,
+  Post,
+  Req,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { CommonResponse } from 'src/interfaces/common-response.interface';
+import { ImageDto } from './dto/image.dto';
+import { v4 as uuidv4 } from 'uuid';
+import * as sharp from 'sharp';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
+import { UrlDto } from './dto/url.dto';
+import { S3Service } from './s3.service';
+import { Request } from 'express';
+import { User } from 'src/entities/user.entity';
+import { ImageService } from './image.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Image } from 'src/entities/image.entity';
+import { Repository } from 'typeorm';
+
+/**
+ * 임시로 만든 컨트롤러. 업로드 시에 이미지 주인을 데이터베이스에 넣는 로직을 추가했습니다.
+ * 삭제시 imgService.deleteByUrlAndUser(user) 가 올바르게 동작하는지 확인하기 위해서 사용됩니다.
+ */
+@Controller('image')
+export class ImageController {
+  constructor(
+    private readonly s3Service: S3Service,
+    private readonly imgService: ImageService,
+    @InjectRepository(Image) private readonly imgRepository: Repository<Image>,
+  ) {}
+
+  @Post()
+  @UseInterceptors(FilesInterceptor('files'))
+  @UseGuards(JwtAuthGuard)
+  async uploadFiles(
+    @UploadedFiles(
+      new ParseFilePipe({
+        validators: [new FileTypeValidator({ fileType: 'image/*' })],
+      }),
+    )
+    files: Express.Multer.File[],
+    @Req() req: Request,
+  ): Promise<CommonResponse> {
+    const user = req.user as User;
+    const uploadedImages = new ImageDto();
+    const uploadPromises = files.map(async (file): Promise<string> => {
+      const buffer = await sharp(file.buffer).resize(300).toBuffer();
+
+      const regex = /\.([0-9a-z]+)(?:[\?#]|$)/i;
+      const match = file.originalname.match(regex);
+      const extension = match[1];
+
+      const filename = uuidv4() + '.' + extension;
+
+      const url = this.s3Service.upload(filename, buffer);
+      return url;
+    });
+    const urls = await Promise.all(uploadPromises);
+
+    uploadedImages.urls = urls;
+
+    // DB에 임시 인스턴스를 저장
+    const savePromises = urls.map(async (url): Promise<void> => {
+      const image = new Image(url, null, null);
+      image.creator = user;
+      await this.imgRepository.save(image);
+    });
+    await Promise.all(savePromises);
+
+    return {
+      message: '성공적으로 파일이 업로드 되었습니다.',
+      data: uploadedImages,
+    };
+  }
+
+  /**
+   * 파일 URL로부터 파일명을 추출한 다음
+   * 데이터베이스에 저장이 되어있는지 확인한 후
+   * S3에 저장된 파일을 포함하여 제거합니다.
+   * @authorization JWT Bearer Token
+   * @param imgUrl 제거하고자 하는 이미지의 파일 URL
+   * @todo 자신이 올린 이미지를 제외한 파일은 제거하지 못하도록 정책을 추가해야 합니다.
+   */
+  @Delete()
+  @UseGuards(JwtAuthGuard)
+  async deleteFile(
+    @Req() req: Request,
+    @Body() urlDto: UrlDto,
+  ): Promise<CommonResponse> {
+    const user = req.user as { user: User } as any;
+    const { url } = urlDto;
+
+    await this.imgService.deleteByUrlAndUser(url, user);
+
+    await this.s3Service.delete(url);
+
+    return {
+      message: '성공적으로 파일이 삭제되었습니다.',
+      data: null,
+    };
+  }
+}


### PR DESCRIPTION
[WISH-292 "유저는 자기가 만든 이미지만 삭제 가능하게 강제해야 합니다"](https://wishfund.atlassian.net/browse/WISH-292) 지라 스토리에 대한 코드 기여 입니다. image delete시에 `image.service.deleteByUrlAndUser`를 사용하여 req.user가 업로드한 이미지인지 확인합니다. 

## change

Image 테이블에 `creatorUserId` 컬럼이 생성되었습니다. 현재 dev1 데이터베이스에 적용되어 있습니다.

![Screenshot From 2024-10-01 00-07-15](https://github.com/user-attachments/assets/4a5c0889-fa12-4ab0-8fb3-32965d6afeaf)

Image 테이블의 `imgType` NOT NULL 속성이 해제되었습니다.

`src/features/image/image2.service.ts` 파일이 추가되었고 기존 image.service.ts 파일로부터 upload 로직에 내용이 추가되었습니다. [notice](#notice)를 참조하세요.

user entity에 연관 이미지 Array인 `createdImages: Array<Image>`가 추가되었습니다. OneToMany 데코레이터가 달려있습니다.

## notice

현재 이미지 업로드 시 DB에 `creatorUserId`가 추가된 임시 인스턴스가 만들어지는 로직을 `src/features/image/image2.service.ts` 파일에 만들어놓았습니다. 하단에 DIFF 결과를 함께 첨부해드립니다. `image.module.ts` 파일의 임포트에 현재 `image2.service.ts`로 변경되어있습니다. 다음 PR이 머지될때 되돌려놓겠습니다.

![Screenshot From 2024-09-30 23-39-23](https://github.com/user-attachments/assets/8d719e91-4718-4bcf-9440-16935070e437)

임시 파일로 만들어놓은 이유는 다름아닌 별개의 브랜치 #WISH-304 로 브랜치 올릴 예정이기 때문입니다.

## 결론

이미지 업로드 API는 임시로 user 정보를 DB에 넣었습니다. 하단 이미지의 `creatorUserId` 컬럼을 확인하시면 됩니다.

![Screenshot From 2024-09-30 23-24-39](https://github.com/user-attachments/assets/2978b67d-5d75-40e0-bc4b-a693df9425ba)

이미지 삭제시 본인의 경우에는 성공적으로 삭제 완료되는 모습을 테스트 완료했습니다. 하지만 본인이 아닌 유저가 남의 URL을 제거하려고 시도할 경우 아래와 같이 404 에러가 발생하게 됩니다:

![Screenshot From 2024-09-30 23-32-38](https://github.com/user-attachments/assets/5b6baa3a-9c5c-4ec6-acdc-fb0dd236472e)
