### PR TITLE
WISH-306-Refactoring-Image-Get

### DIFF
--- a/src/features/gratitude/gratitude.service.ts
+++ b/src/features/gratitude/gratitude.service.ts
@@ -23,9 +23,6 @@ export class GratitudeService {
     @InjectRepository(Funding)
     private readonly fundingRepo: Repository<Funding>,
 
-    @InjectRepository(Image)
-    private readonly imgRepo: Repository<Image>,
-
     private readonly g2gException: GiftogetherExceptions,
 
     private eventEmitter: EventEmitter2,
@@ -47,14 +44,13 @@ export class GratitudeService {
     let returnImgUrl: string[] = [];
 
     if (grat.defaultImgId) {
-      const img = await this.imgRepo.findOne({
-        where: { imgId: grat.defaultImgId },
-      });
+      const img = await this.imgService.getInstanceByPK(grat.defaultImgId);
       returnImgUrl.push(img.imgUrl);
     } else {
-      const images = await this.imgRepo.find({
-        where: { imgType: ImageType.Gratitude, subId: grat.gratId },
-      });
+      const images = await this.imgService.getInstancesBySubId(
+        ImageType.Gratitude,
+        grat.gratId,
+      );
       returnImgUrl.push(...images.map((i) => i.imgUrl));
     }
 
@@ -108,11 +104,7 @@ export class GratitudeService {
       if (!DefaultImageIds.Gratitude.includes(gratitudeDto.defaultImgId))
         throw this.g2gException.DefaultImgIdNotExist;
 
-      const image = await this.imgRepo.findOne({
-        where: {
-          imgId: gratitudeDto.defaultImgId,
-        },
-      });
+      const image = await this.imgService.getInstanceByPK(grat.defaultImgId);
       returnImgUrl.push(image.imgUrl);
     }
 
@@ -186,9 +178,7 @@ export class GratitudeService {
       this.imgService.delete(ImageType.Gratitude, gratId);
 
       // 3.
-      const image = await this.imgRepo.findOne({
-        where: { imgId: defaultImgId },
-      });
+      const image = await this.imgService.getInstanceByPK(grat.defaultImgId);
       imgUrl = [image.imgUrl];
     }
     return new GetGratitudeDto(funding.fundUuid, gratTitle, gratCont, imgUrl);

--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -22,6 +22,10 @@ export class ImageService {
     });
   }
 
+  async getInstanceByPK(imgId: number): Promise<Image> {
+    return this.imgRepo.findOne({ where: { imgId } });
+  }
+
   /**
    * 이미지를 생성하거나 업데이트합니다.
    *
@@ -70,7 +74,7 @@ export class ImageService {
       // 동일한 이미지
       return foundImg;
     }
-    
+
     throw this.g2gException.ImageAlreadyExists;
   }
 

--- a/src/features/rolling-paper/rolling-paper.service.ts
+++ b/src/features/rolling-paper/rolling-paper.service.ts
@@ -4,7 +4,6 @@ import { RollingPaper } from 'src/entities/rolling-paper.entity';
 import { Repository } from 'typeorm';
 import { RollingPaperDto } from './dto/rolling-paper.dto';
 import { Funding } from 'src/entities/funding.entity';
-import { Image } from 'src/entities/image.entity';
 import { ImageType } from 'src/enums/image-type.enum';
 import { Donation } from 'src/entities/donation.entity';
 import { CreateRollingPaperDto } from './dto/create-rolling-paper.dto';
@@ -22,9 +21,6 @@ export class RollingPaperService {
 
     @InjectRepository(Funding)
     private readonly fundingRepo: Repository<Funding>,
-
-    @InjectRepository(Image)
-    private readonly imgRepo: Repository<Image>,
 
     private readonly g2gException: GiftogetherExceptions,
 
@@ -58,20 +54,18 @@ export class RollingPaperService {
 
     const getImageUrl = async (roll: RollingPaper): Promise<string> => {
       if (roll.defaultImgId) {
-        return (
-          await this.imgRepo.findOne({
-            where: { imgId: roll.defaultImgId },
-          })
-        )?.imgUrl;
+        return (await this.imgService.getInstanceByPK(roll.defaultImgId))
+          ?.imgUrl;
       }
 
       // not a default
       Logger.log(`롤링페이퍼 ID: ${roll.rollId}`);
       return (
-        await this.imgRepo.findOne({
-          where: { imgType: ImageType.RollingPaper, subId: roll.rollId },
-        })
-      )?.imgUrl;
+        await this.imgService.getInstancesBySubId(
+          ImageType.RollingPaper,
+          roll.rollId,
+        )
+      )[0]?.imgUrl;
     };
 
     const resolvedRolls = await Promise.all(rolls);

--- a/src/features/user/user.service.ts
+++ b/src/features/user/user.service.ts
@@ -3,8 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { Account } from 'src/entities/account.entity';
-import { Image } from 'src/entities/image.entity';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { ImageType } from 'src/enums/image-type.enum';
 import { UserDto } from './dto/user.dto';
@@ -17,22 +15,18 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-    @InjectRepository(Account)
-    private readonly accRepository: Repository<Account>,
-    @InjectRepository(Image)
-    private readonly imgRepository: Repository<Image>,
-
     private readonly g2gException: GiftogetherExceptions,
-    
+
     private readonly imgService: ImageService,
   ) {}
 
   // 사용자 정보 조회
   async getUserInfo(user: User): Promise<UserDto> {
-    const where = user.defaultImgId
-      ? { imgId: user.defaultImgId }
-      : { imgType: ImageType.User, subId: user.userId };
-    const image = await this.imgRepository.findOne({ where });
+    const image = user.defaultImgId
+      ? await this.imgService.getInstanceByPK(user.defaultImgId)
+      : (
+          await this.imgService.getInstancesBySubId(ImageType.User, user.userId)
+        )[0];
 
     return new UserDto(
       user.userNick,
@@ -52,10 +46,11 @@ export class UserService {
   async getOthersInfo(userId: number): Promise<UserDto> {
     const user = await this.userRepository.findOne({ where: { userId } });
 
-    const where = user.defaultImgId
-      ? { imgId: user.defaultImgId }
-      : { imgType: ImageType.User, subId: user.userId };
-    const image = await this.imgRepository.findOne({ where });
+    const image = user.defaultImgId
+      ? await this.imgService.getInstanceByPK(user.defaultImgId)
+      : (
+          await this.imgService.getInstancesBySubId(ImageType.User, user.userId)
+        )[0];
 
     return new UserDto(
       user.userNick,
@@ -98,46 +93,36 @@ export class UserService {
 
       user.defaultImgId = null;  // 기본 이미지 ID를 null로 설정
       imageUrl = savedImage.imgUrl;  // 이미지 URL 설정
-    } else if (defaultImgId) { // 기본 이미지가 제공된 경우
+    } else if (defaultImgId) {
+      // 기본 이미지가 제공된 경우
       // 기본 이미지 ID가 유효한지 확인
       if (!DefaultImageIds.User.includes(defaultImgId)) {
         throw this.g2gException.DefaultImgIdNotExist;
       }
-  
+
       // 기존 사용자 지정 프로필 이미지가 있는 경우 삭제
       if (!user.defaultImgId) {
         await this.imgService.delete(ImageType.User, userId);
       }
-  
-      const defaultImage = await this.imgRepository.findOne({
-        where: { imgId: defaultImgId },
-      });
-  
+
+      const defaultImage = await this.imgService.getInstanceByPK(defaultImgId);
+
       if (defaultImage) {
-        user.defaultImgId = defaultImage.imgId;  // 기본 이미지 ID 설정
-        imageUrl = defaultImage.imgUrl;  // 이미지 URL 설정
+        user.defaultImgId = defaultImage.imgId; // 기본 이미지 ID 설정
+        imageUrl = defaultImage.imgUrl; // 이미지 URL 설정
       } else {
         throw this.g2gException.DefaultImgIdNotExist;
       }
     } else { // 기본 이미지나 사용자 지정 이미지가 제공되지 않은 경우
-      if (user.defaultImgId) {
-        const image = await this.imgRepository.findOne({
-          where: { imgId: user.defaultImgId },
-        });
-        if (image) {
-          imageUrl = image.imgUrl;  // 기존 기본 이미지의 URL 설정
-        }
-      } else {
-        const image = await this.imgRepository.findOne({
-          where: { 
-            imgType: ImageType.User,
-            subId: userId,
-          },
-        });
-        if (image) {
-          imageUrl = image.imgUrl;  // 기존 사용자 지정 이미지의 URL 설정
-        }
-      }
+      const image = user.defaultImgId
+        ? await this.imgService.getInstanceByPK(user.defaultImgId)
+        : (
+            await this.imgService.getInstancesBySubId(
+              ImageType.User,
+              user.userId,
+            )
+          )[0];
+      imageUrl = image ? image.imgUrl : null;
     }
   
     // 3. 비밀번호 해시 처리
@@ -169,12 +154,10 @@ export class UserService {
     await this.userRepository.softDelete(user.userId);
 
     const image = user.defaultImgId
-      ? await this.imgRepository.findOne({
-          where: { imgId: user.defaultImgId },
-        })
-      : await this.imgRepository.findOne({
-          where: { imgType: ImageType.User, subId: user.userId },
-        });
+      ? await this.imgService.getInstanceByPK(user.defaultImgId)
+      : (
+          await this.imgService.getInstancesBySubId(ImageType.User, user.userId)
+        )[0];
 
     return new UserDto(
       user.userNick,


### PR DESCRIPTION
## Interfaces

- `ImageService.getInstancesBySubId`: `ImageType`과 `subId` 두개의 인자를 받아 FK 관계로 묶여있는 모든 이미지들을 가지고 옵니다.
- `ImageService.getInstanceByPK`: `imgId` PK를 사용하여 이미지를 가지고 옵니다.

## 테스트 완료 목록

- `FundingService`
	- `findOne`	
	- `create`
	- `update`
- `GiftService`
	- `getGiftImgUrl`
	- `handleGiftRemoval`
	- `setDefaultGiftImage`
- `GratitudeService`
	- `getGratitude`
	- `createGratitude`
	- `updateGratitude`
- `UserService`
	- `getUserInfo`
	- `getOthersInfo`
	- `updateUser`
	- `deleteUser`