### PR TITLE
🗃️ feat(gift): Set giftCont length to 20

### DIFF
--- a/src/entities/gift.entity.ts
+++ b/src/entities/gift.entity.ts
@@ -28,7 +28,7 @@ export class Gift {
   @Column({ nullable: true })
   giftOpt: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, length: 20 })
   giftCont: string;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## 10월 16일 회의록 참고

https://www.notion.so/10-16-0bf6f8d1c9454c8b9f96c53e4647763a?pvs=4

Gift 설명란이 긴 경우 아이템 컴포넌트를 글씨가 삐져나오는 것을 막기 위해서 글자 길이 제한을 두었습니다.

## 적용

현재 dev1 데이터베이스에만 적용 완료한 상태입니다. PR 머지 이후 postgres 데이터베이스에도 적용 필요합니다.