### PR TITLE
🐳 CI: Add dockerfile & compose for dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Docker Node.js Launch",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "platform": "node"
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Node in Docker",
+            "port": 9229,
+            "address": "localhost",
+            "restart": true,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/usr/src/app",
+            "protocol": "inspector",
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "docker-build",
+            "label": "docker-build",
+            "platform": "node",
+            "dockerBuild": {
+                "dockerfile": "${workspaceFolder}/Dockerfile",
+                "context": "${workspaceFolder}",
+                "pull": true
+            }
+        },
+        {
+            "type": "docker-run",
+            "label": "docker-run: release",
+            "dependsOn": [
+                "docker-build"
+            ],
+            "platform": "node"
+        },
+        {
+            "type": "docker-run",
+            "label": "docker-run: debug",
+            "dependsOn": [
+                "docker-build"
+            ],
+            "dockerRun": {
+                "env": {
+                    "DEBUG": "*",
+                    "NODE_ENV": "development"
+                }
+            },
+            "node": {
+                "enableDebugging": true
+            }
+        },
+        {
+            "label": "Docker Compose: Up",
+            "type": "shell",
+            "command": "docker-compose -f docker-compose.development.yml up --build",
+            "problemMatcher": [],
+            "detail": "Run docker-compose up with development settings"
+        },
+        {
+            "label": "Docker Compose: Down",
+            "type": "shell",
+            "command": "docker-compose -f docker-compose.development.yml down",
+            "problemMatcher": [],
+            "detail": "Run docker-compose down"
+        }
+    ]
+}

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,16 @@
+# Base image
+FROM node:20
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Port number
+EXPOSE 3000
+COPY . .
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install
+
+# Start the server
+CMD ["npm", "run", "start:debug"]

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   giftogether:
     build:
@@ -8,19 +6,21 @@ services:
     image: giftogether-dev:WISH-317
     container_name: giftogether
     ports:
-      - "3000:3000"
+      - "3000:3000" # app port
+      - "9229:9229" # Debugging port
     networks:
       - g2gnet
     volumes:
       - .:/usr/src/app # 라이브 리로딩 기능을 위한 마운트
       - /usr/src/app/node_modules # prevents node_modules conflicts
-    command: npm run start:dev
     depends_on:
       - redis
     env_file:
       - .env
     environment:
       NODE_ENV: development
+    command: |
+      node --inspect=0.0.0.0:9229 -r ts-node/register -r tsconfig-paths/register src/main.ts
 
   redis:
     image: redis:7.4.1

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  giftogether:
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    image: giftogether-dev:WISH-317
+    container_name: giftogether
+    ports:
+      - "3000:3000"
+    networks:
+      - g2gnet
+    volumes:
+      - .:/usr/src/app # 라이브 리로딩 기능을 위한 마운트
+      - /usr/src/app/node_modules # prevents node_modules conflicts
+    command: npm run start:dev
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: development
+
+  redis:
+    image: redis:7.4.1
+    container_name: g2gredis
+    ports:
+      - "6379:6379"
+    networks:
+      - g2gnet
+    volumes:
+      - ./docker/redis.conf:/usr/local/etc/redis/redis.conf
+    command: redis-server /usr/local/etc/redis/redis.conf
+
+networks:
+  g2gnet:
+    driver: bridge


### PR DESCRIPTION
## DONE

- watch mode ⭕️
- debug ⭕️
- tag: JIRA 고윳값으로 해놨음. `WISH-317` 다만, EC2에서 달고 있는 태그와 맞추는 것이 더 좋을지도?

**실행방법 (Terminal)**

```
docker-compose -f docker-compose.development.yml up
```

detached 모드는 `-d` 붙이면 됩니다.

**실행방법 (VSCode, Debug)**

별도의 터미널에서 docker-compose up을 해도 되고 아니면 바로 "Run and Debug" 탭에 가서 "Attach to Node in Docker" 타겟을 실행해도 됩니다.

![image](https://github.com/user-attachments/assets/135fe9b3-df10-4d35-b9cb-f794720071e4)

**실행방법 (VSCode, Run)**

> **prerequisite**: VSCode에 [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) 공식 확장을 설치해야합니다

Ctrl + Shift + P를 눌러 커맨드 프롬프트를 띄운 뒤에 "Docker Compose Up"을 입력하여 나타나는 항목을 클릭합니다. 그리고 원하는 yml 파일을 선택하면 됩니다.


## Docker Bind Mount 관련 유의사항

`docker-compose.development.yml` 파일에 보면 바인드 마운트를 볼 수 있습니다:

```yml
...
   volumes:
      - .:/usr/src/app # 라이브 리로딩 기능을 위한 마운트
```

다름이 아니고 도커교과서에 따르면 리눅스와 윈도우 사이의 작동방식이 다를 수 있다고 하기에 윈도우 사용자 @coding-jjun 는 한 번 실행해 보고 정상적으로 작동하는지 확인이 필요합니다.